### PR TITLE
Configure Terraform S3 Remote State Backend with DynamoDB Locking

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "fraud-detection-tfstate-2026"
+    key            = "nyc-taxi-pipeline/terraform.tfstate"
+    region         = "us-east-2"
+    dynamodb_table = "fraud-detection-tflock"
+    encrypt        = true
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,7 @@ variable "project_name" {
 variable "aws_region" {
   description = "AWS region to deploy into"
   type        = string
-  default     = "us-east-1"
+  default     = "us-east-2"
 }
 
 variable "environment" {


### PR DESCRIPTION
## Summary

This PR moves Terraform state management from local to a remote S3 backend with DynamoDB-based state locking, enabling safe collaboration and durable state storage.

closes #4 
## Changes

### 1. Bootstrap configuration (`bootstrap/main.tf`)

Creates the prerequisite infrastructure that Terraform's backend depends on:

- **S3 Bucket** 

- **DynamoDB Table**

### 2. Backend configuration (`backend.tf`)

```hcl
terraform {
  backend "s3" {
    bucket         = "fraud-detection-tfstate-2026"
    key            = "nyc-taxi-pipeline/terraform.tfstate"
    region         = "us-east-2"
    dynamodb_table = "fraud-detection-tflock"
    encrypt        = true
  }
}
```
## Testing

- [x] `terraform init` completes successfully against the S3 backend.
- [x] `terraform plan` shows no unexpected changes.
- [x] State locking verified — concurrent runs receive a lock error as expected.
- [x] State file is encrypted and versioned in S3.