### PR TITLE
Add pre-commit hooks for ruff check and ruff format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,14 @@ jobs:
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
 
+      - name: Install dependencies
+        run: uv sync --group dev
+
       - name: Run ruff linter
-        run: uvx ruff check src/ tests/
+        run: uv run ruff check src/ tests/
 
       - name: Run ruff formatter check
-        run: uvx ruff format --check src/ tests/
+        run: uv run ruff format --check src/ tests/
 
   # ─── Unit Tests ──────────────────────────────────────────────────────────
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos: #ruff's official pre-commit repo.
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9 #without pinning ruff version, hooks would drift over time
+    rev: v0.15.10 #without pinning ruff version, hooks would drift over time
     hooks:
       - id: ruff #same as ruff check --fix
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos: #ruff's official pre-commit repo.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9 #without pinning ruff version, hooks would drift over time
+    hooks:
+      - id: ruff #same as ruff check --fix
+        args: [--fix]
+      - id: ruff-format #same as ruff format

--- a/airflow/dags/nyc_taxi_pipeline_dag.py
+++ b/airflow/dags/nyc_taxi_pipeline_dag.py
@@ -18,22 +18,17 @@ Architecture Notes:
 - Quality checks run as Python callables after each stage
 """
 
-from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta
-import json
 import logging
 import os
-import time
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessStartJobOperator,
 )
-from airflow.providers.amazon.aws.sensors.emr import (
-    EmrServerlessJobSensor,
-)
 from airflow.utils.task_group import TaskGroup
+from dateutil.relativedelta import relativedelta
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +65,7 @@ default_args = {
 
 # ─── Helper Functions ────────────────────────────────────────────────────────
 
+
 def get_processing_period(**context):
     """
     Determine which year/month to process based on the DAG's logical_date.
@@ -94,9 +90,10 @@ def get_processing_period(**context):
 def ingest_taxi_data(**context):
     """Ingest yellow (and optionally green) taxi data."""
     import sys
+
     sys.path.insert(0, "/opt/airflow/src")
-    from ingestion.nyc_tlc_ingestion import ingest_yellow_taxi, ingest_green_taxi
     from config import Config
+    from ingestion.nyc_tlc_ingestion import ingest_green_taxi, ingest_yellow_taxi
 
     ti = context["ti"]
     year = ti.xcom_pull(key="process_year")
@@ -119,9 +116,10 @@ def ingest_taxi_data(**context):
 def ingest_weather_data(**context):
     """Ingest NOAA weather data for the processing year."""
     import sys
+
     sys.path.insert(0, "/opt/airflow/src")
-    from ingestion.noaa_weather_ingestion import ingest_weather
     from config import Config
+    from ingestion.noaa_weather_ingestion import ingest_weather
 
     ti = context["ti"]
     year = ti.xcom_pull(key="process_year")
@@ -139,12 +137,13 @@ def ingest_weather_data(**context):
 def run_quality_checks(check_type: str, **context):
     """Run data quality checks for the specified layer."""
     import sys
+
     sys.path.insert(0, "/opt/airflow/src")
     from quality.data_quality_checks import (
-        run_bronze_taxi_checks,
-        run_silver_taxi_checks,
-        run_gold_checks,
         evaluate_results,
+        run_bronze_taxi_checks,
+        run_gold_checks,
+        run_silver_taxi_checks,
     )
 
     ti = context["ti"]
@@ -166,8 +165,9 @@ def run_quality_checks(check_type: str, **context):
 
 def upload_spark_scripts(**context):
     """Upload PySpark scripts to S3 so EMR Serverless can access them."""
-    import boto3
     import glob
+
+    import boto3
 
     s3_client = boto3.client("s3", region_name=AWS_REGION)
     script_dir = "/opt/airflow/src/transformation"
@@ -192,7 +192,6 @@ with DAG(
     max_active_runs=1,  # Process one month at a time
     tags=["nyc-taxi", "etl", "monthly"],
 ) as dag:
-
     # ── Step 0: Determine processing period ──
     determine_period = PythonOperator(
         task_id="determine_processing_period",
@@ -237,10 +236,14 @@ with DAG(
                         "bronze_to_silver_taxi.py"
                     ),
                     "entryPointArguments": [
-                        "--data-bucket", DATA_BUCKET,
-                        "--year", "{{ ti.xcom_pull(key='process_year') }}",
-                        "--month", "{{ ti.xcom_pull(key='process_month') }}",
-                        "--glue-database", GLUE_DB_SILVER,
+                        "--data-bucket",
+                        DATA_BUCKET,
+                        "--year",
+                        "{{ ti.xcom_pull(key='process_year') }}",
+                        "--month",
+                        "{{ ti.xcom_pull(key='process_month') }}",
+                        "--glue-database",
+                        GLUE_DB_SILVER,
                     ],
                     "sparkSubmitParameters": (
                         "--conf spark.executor.cores=2 "
@@ -272,9 +275,12 @@ with DAG(
                         "bronze_to_silver_weather.py"
                     ),
                     "entryPointArguments": [
-                        "--data-bucket", DATA_BUCKET,
-                        "--year", "{{ ti.xcom_pull(key='process_year') }}",
-                        "--glue-database", GLUE_DB_SILVER,
+                        "--data-bucket",
+                        DATA_BUCKET,
+                        "--year",
+                        "{{ ti.xcom_pull(key='process_year') }}",
+                        "--glue-database",
+                        GLUE_DB_SILVER,
                     ],
                     "sparkSubmitParameters": (
                         "--conf spark.executor.cores=2 "
@@ -310,15 +316,19 @@ with DAG(
         job_driver={
             "sparkSubmit": {
                 "entryPoint": (
-                    f"s3://{SCRIPTS_BUCKET}/spark-scripts/"
-                    "silver_to_gold_features.py"
+                    f"s3://{SCRIPTS_BUCKET}/spark-scripts/" "silver_to_gold_features.py"
                 ),
                 "entryPointArguments": [
-                    "--data-bucket", DATA_BUCKET,
-                    "--silver-database", GLUE_DB_SILVER,
-                    "--gold-database", GLUE_DB_GOLD,
-                    "--year", "{{ ti.xcom_pull(key='process_year') }}",
-                    "--month", "{{ ti.xcom_pull(key='process_month') }}",
+                    "--data-bucket",
+                    DATA_BUCKET,
+                    "--silver-database",
+                    GLUE_DB_SILVER,
+                    "--gold-database",
+                    GLUE_DB_GOLD,
+                    "--year",
+                    "{{ ti.xcom_pull(key='process_year') }}",
+                    "--month",
+                    "{{ ti.xcom_pull(key='process_month') }}",
                 ],
                 "sparkSubmitParameters": (
                     "--conf spark.executor.cores=2 "
@@ -332,9 +342,7 @@ with DAG(
         },
         configuration_overrides={
             "monitoringConfiguration": {
-                "s3MonitoringConfiguration": {
-                    "logUri": f"s3://{DATA_BUCKET}/emr-logs/"
-                }
+                "s3MonitoringConfiguration": {"logUri": f"s3://{DATA_BUCKET}/emr-logs/"}
             }
         },
     )

--- a/airflow/dags/nyc_taxi_pipeline_dag.py
+++ b/airflow/dags/nyc_taxi_pipeline_dag.py
@@ -232,8 +232,7 @@ with DAG(
             job_driver={
                 "sparkSubmit": {
                     "entryPoint": (
-                        f"s3://{SCRIPTS_BUCKET}/spark-scripts/"
-                        "bronze_to_silver_taxi.py"
+                        f"s3://{SCRIPTS_BUCKET}/spark-scripts/bronze_to_silver_taxi.py"
                     ),
                     "entryPointArguments": [
                         "--data-bucket",
@@ -316,7 +315,7 @@ with DAG(
         job_driver={
             "sparkSubmit": {
                 "entryPoint": (
-                    f"s3://{SCRIPTS_BUCKET}/spark-scripts/" "silver_to_gold_features.py"
+                    f"s3://{SCRIPTS_BUCKET}/spark-scripts/silver_to_gold_features.py"
                 ),
                 "entryPointArguments": [
                     "--data-bucket",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "moto[s3]>=5.0.0",
-    "ruff>=0.3.0",
+    "ruff==0.15.10",
 ]
 # Airflow — separate group because it's heavy and only needed for DAG tests
 airflow = [
@@ -37,7 +37,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "moto[s3]>=5.0.0",
-    "ruff>=0.3.0",
+    "ruff==0.15.10",
     "pre-commit>=4.6.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "moto[s3]>=5.0.0",
     "ruff>=0.3.0",
+    "pre-commit>=4.6.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -90,9 +90,9 @@ class TestAirflowDag:
             from airflow.models import DagBag
 
             dag_bag = DagBag(dag_folder=dag_path, include_examples=False)
-            assert (
-                len(dag_bag.import_errors) == 0
-            ), f"DAG import errors: {dag_bag.import_errors}"
+            assert len(dag_bag.import_errors) == 0, (
+                f"DAG import errors: {dag_bag.import_errors}"
+            )
         except ImportError:
             pytest.skip("Airflow not installed — skipping DAG validation")
 

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -90,9 +90,9 @@ class TestAirflowDag:
             from airflow.models import DagBag
 
             dag_bag = DagBag(dag_folder=dag_path, include_examples=False)
-            assert len(dag_bag.import_errors) == 0, (
-                f"DAG import errors: {dag_bag.import_errors}"
-            )
+            assert (
+                len(dag_bag.import_errors) == 0
+            ), f"DAG import errors: {dag_bag.import_errors}"
         except ImportError:
             pytest.skip("Airflow not installed — skipping DAG validation")
 

--- a/uv.lock
+++ b/uv.lock
@@ -2188,7 +2188,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
 ]
 provides-extras = ["dev", "airflow", "spark"]
 
@@ -2198,7 +2198,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
-    { name = "ruff", specifier = ">=0.3.0" },
+    { name = "ruff", specifier = "==0.15.10" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -632,6 +632,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -962,6 +971,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1028,6 +1046,15 @@ wheels = [
 [package.optional-dependencies]
 standard-no-fastapi-cloud-cli = [
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -1349,6 +1376,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -2016,6 +2052,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2124,6 +2169,7 @@ spark = [
 [package.dev-dependencies]
 dev = [
     { name = "moto", extra = ["s3"] },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -2149,6 +2195,7 @@ provides-extras = ["dev", "airflow", "spark"]
 [package.metadata.requires-dev]
 dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
+    { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.3.0" },
@@ -2427,12 +2474,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -2872,6 +2944,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
 ]
 
 [[package]]
@@ -3733,6 +3818,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  Installed pre-commit and configured it to run ruff check
  (with auto-fix) and ruff format before every commit. Catches lint
  and format issues locally before CI.

  Pre-commit also cleaned up some lint and format issues in files
  we didn't touch in the previous PR (airflow/dags/, test files).

  Closes #11