### PR TITLE
Update deprecated Airflow imports to current paths

### DIFF
--- a/airflow/dags/nyc_taxi_pipeline_dag.py
+++ b/airflow/dags/nyc_taxi_pipeline_dag.py
@@ -23,11 +23,11 @@ import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessStartJobOperator,
 )
-from airflow.utils.task_group import TaskGroup
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import TaskGroup
 from dateutil.relativedelta import relativedelta
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Resolve two deprecation warnings in the DAG file:
  - PythonOperator: airflow.operators.python → airflow.providers.standard.operators.python
  - TaskGroup: airflow.utils.task_group → airflow.sdk

  Note: The original issue mentioned a third deprecation (schedule_interval → schedule),
  but that fix is already on main. The fix/airflow-dag-ci-test branch is therefore
  redundant and can be deleted after this PR merges.

  Closes #16 