### PR TITLE
Fix Glue catalog integration: SparkSession config + IAM resource scope

### DIFF
--- a/src/transformation/bronze_to_silver_taxi.py
+++ b/src/transformation/bronze_to_silver_taxi.py
@@ -36,6 +36,12 @@ def create_spark_session(app_name: str = "bronze_to_silver_taxi") -> SparkSessio
         SparkSession.builder.appName(app_name)
         .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
         .config("spark.sql.parquet.compression.codec", "snappy")
+        .config("spark.sql.catalogImplementation", "hive")
+        .config(
+            "spark.hadoop.hive.metastore.client.factory.class",
+            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+        )
+        .enableHiveSupport()
         .getOrCreate()
     )
 

--- a/src/transformation/bronze_to_silver_weather.py
+++ b/src/transformation/bronze_to_silver_weather.py
@@ -27,6 +27,12 @@ def create_spark_session() -> SparkSession:
     return (
         SparkSession.builder.appName("bronze_to_silver_weather")
         .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
+        .config("spark.sql.catalogImplementation", "hive")
+        .config(
+            "spark.hadoop.hive.metastore.client.factory.class",
+            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+        )
+        .enableHiveSupport()
         .getOrCreate()
     )
 

--- a/src/transformation/silver_to_gold_features.py
+++ b/src/transformation/silver_to_gold_features.py
@@ -26,6 +26,12 @@ def create_spark_session() -> SparkSession:
     return (
         SparkSession.builder.appName("silver_to_gold_features")
         .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
+        .config("spark.sql.catalogImplementation", "hive")
+        .config(
+            "spark.hadoop.hive.metastore.client.factory.class",
+            "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory",
+        )
+        .enableHiveSupport()
         .getOrCreate()
     )
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -108,8 +108,8 @@ resource "aws_iam_role_policy" "emr_glue_access" {
         ]
         Resource = [
           "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog",
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${var.project_name}_*",
-          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.project_name}_*/*"
+          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/*",
+          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/*/*"
         ]
       }
     ]


### PR DESCRIPTION
Two bugs caught during first end-to-end EMR Serverless run:

  1. All three PySpark scripts claimed Glue catalog integration in
     docstrings but the SparkSession.builder didn't configure it. Added
     spark.sql.catalogImplementation=hive, the AWS Glue Hive client
     factory class, and enableHiveSupport() to all three.

  2. EMR Serverless IAM policy scoped Glue access to
     database/${var.project_name}_* — but var.project_name is
     "nyc-taxi-pipeline" (hyphens) while the actual Glue databases are
     "nyc_taxi_pipeline_*" (underscores), so the pattern matched nothing.
     Plus Spark's Hive context touches the "default" database during init
     even when not using it. Broadened resource scope to database/* and
     table/*/*.

  Closes #20.

  Tested locally by inspection. End-to-end verification requires
  terraform apply + manual EMR job submit (next step).