### PR TITLE
Migrate pipeline from bucket-name to data-lake URI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ airflow-restart: ## Restart Airflow
 # ─── Deployment ────────────────────────────────────────────────────────────
 deploy-scripts: ## Upload PySpark scripts to S3
 	@echo "Uploading PySpark scripts to S3..."
-	aws s3 sync src/transformation/ s3://$${SCRIPTS_BUCKET}/spark-scripts/ \
+	aws s3 sync src/transformation/ $${SCRIPTS_LOCATION}/ \
 		--exclude "__pycache__/*" --exclude "*.pyc" --exclude "__init__.py"
 	@echo "Done!"
 

--- a/airflow/.env.example
+++ b/airflow/.env.example
@@ -1,13 +1,13 @@
 # Copy this to .env and fill in values from `terraform output -json`
 # These are consumed by docker-compose.yaml
 
-DATA_BUCKET=nyc-taxi-pipeline-data-lake-dev
-SCRIPTS_BUCKET=nyc-taxi-pipeline-scripts-dev
+DATA_LAKE_ROOT=s3://nateeatsrice-master-s3/data-lake
+SCRIPTS_LOCATION=s3://nateeatsrice-master-s3/scripts/data-pipeline
 EMR_APP_ID=your-emr-app-id-here
 EMR_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/nyc-taxi-pipeline-emr-serverless-role-dev
-GLUE_DB_BRONZE=nyc_taxi_pipeline_bronze_dev
-GLUE_DB_SILVER=nyc_taxi_pipeline_silver_dev
-GLUE_DB_GOLD=nyc_taxi_pipeline_gold_dev
+GLUE_DB_BRONZE=data_pipeline_bronze_dev
+GLUE_DB_SILVER=data_pipeline_silver_dev
+GLUE_DB_GOLD=data_pipeline_gold_dev
 AWS_REGION=us-east-1
 
 # Option 1: Set AWS credentials directly (not recommended for production)

--- a/airflow/dags/nyc_taxi_pipeline_dag.py
+++ b/airflow/dags/nyc_taxi_pipeline_dag.py
@@ -36,14 +36,19 @@ logger = logging.getLogger(__name__)
 # These come from environment variables set in docker-compose or .env file.
 # They map to Terraform outputs.
 
-DATA_BUCKET = os.getenv("DATA_BUCKET", "nyc-taxi-pipeline-data-lake-dev")
-SCRIPTS_BUCKET = os.getenv("SCRIPTS_BUCKET", "nyc-taxi-pipeline-scripts-dev")
+DATA_LAKE_ROOT = os.getenv("DATA_LAKE_ROOT", "s3://nateeatsrice-master-s3/data-lake")
+SCRIPTS_LOCATION = os.getenv(
+    "SCRIPTS_LOCATION", "s3://nateeatsrice-master-s3/scripts/data-pipeline"
+)
+# Bare bucket name + key prefix for boto3 upload_file (needs name, not URI)
+MASTER_BUCKET = "nateeatsrice-master-s3"
+SCRIPTS_KEY_PREFIX = "scripts/data-pipeline"
 EMR_APP_ID = os.getenv("EMR_APP_ID", "")
 EMR_EXECUTION_ROLE_ARN = os.getenv("EMR_EXECUTION_ROLE_ARN", "")
-GLUE_DB_BRONZE = os.getenv("GLUE_DB_BRONZE", "nyc_taxi_pipeline_bronze_dev")
-GLUE_DB_SILVER = os.getenv("GLUE_DB_SILVER", "nyc_taxi_pipeline_silver_dev")
-GLUE_DB_GOLD = os.getenv("GLUE_DB_GOLD", "nyc_taxi_pipeline_gold_dev")
-AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+GLUE_DB_BRONZE = os.getenv("GLUE_DB_BRONZE", "data_pipeline_bronze_dev")
+GLUE_DB_SILVER = os.getenv("GLUE_DB_SILVER", "data_pipeline_silver_dev")
+GLUE_DB_GOLD = os.getenv("GLUE_DB_GOLD", "data_pipeline_gold_dev")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-2")
 
 # TLC publishes data with ~2 month lag, so for a run on 2025-03-05,
 # we process data for 2025-01 (the logical_date's month).
@@ -156,7 +161,7 @@ def run_quality_checks(check_type: str, **context):
         "gold": run_gold_checks,
     }
 
-    results = check_fns[check_type](DATA_BUCKET, year, month)
+    results = check_fns[check_type](DATA_LAKE_ROOT, year, month)
     passed = evaluate_results(results)
 
     if not passed:
@@ -174,9 +179,11 @@ def upload_spark_scripts(**context):
 
     for filepath in glob.glob(f"{script_dir}/*.py"):
         filename = os.path.basename(filepath)
-        s3_key = f"spark-scripts/{filename}"
-        logger.info(f"Uploading {filename} to s3://{SCRIPTS_BUCKET}/{s3_key}")
-        s3_client.upload_file(filepath, SCRIPTS_BUCKET, s3_key)
+        s3_key = f"{filename}"
+        logger.info(
+            f"Uploading {filename} to s3://{MASTER_BUCKET}/{SCRIPTS_KEY_PREFIX}/{s3_key}"
+        )
+        s3_client.upload_file(filepath, MASTER_BUCKET, f"{SCRIPTS_KEY_PREFIX}/{s3_key}")
 
 
 # ─── DAG Definition ──────────────────────────────────────────────────────────
@@ -231,12 +238,10 @@ with DAG(
             execution_role_arn=EMR_EXECUTION_ROLE_ARN,
             job_driver={
                 "sparkSubmit": {
-                    "entryPoint": (
-                        f"s3://{SCRIPTS_BUCKET}/spark-scripts/bronze_to_silver_taxi.py"
-                    ),
+                    "entryPoint": (f"{SCRIPTS_LOCATION}/bronze_to_silver_taxi.py"),
                     "entryPointArguments": [
-                        "--data-bucket",
-                        DATA_BUCKET,
+                        "--data-root",
+                        DATA_LAKE_ROOT,
                         "--year",
                         "{{ ti.xcom_pull(key='process_year') }}",
                         "--month",
@@ -257,7 +262,7 @@ with DAG(
             configuration_overrides={
                 "monitoringConfiguration": {
                     "s3MonitoringConfiguration": {
-                        "logUri": f"s3://{DATA_BUCKET}/emr-logs/"
+                        "logUri": f"{DATA_LAKE_ROOT}/emr-logs/"
                     }
                 }
             },
@@ -269,13 +274,10 @@ with DAG(
             execution_role_arn=EMR_EXECUTION_ROLE_ARN,
             job_driver={
                 "sparkSubmit": {
-                    "entryPoint": (
-                        f"s3://{SCRIPTS_BUCKET}/spark-scripts/"
-                        "bronze_to_silver_weather.py"
-                    ),
+                    "entryPoint": (f"{SCRIPTS_LOCATION}/bronze_to_silver_weather.py"),
                     "entryPointArguments": [
-                        "--data-bucket",
-                        DATA_BUCKET,
+                        "--data-root",
+                        DATA_LAKE_ROOT,
                         "--year",
                         "{{ ti.xcom_pull(key='process_year') }}",
                         "--glue-database",
@@ -294,7 +296,7 @@ with DAG(
             configuration_overrides={
                 "monitoringConfiguration": {
                     "s3MonitoringConfiguration": {
-                        "logUri": f"s3://{DATA_BUCKET}/emr-logs/"
+                        "logUri": f"{DATA_LAKE_ROOT}/emr-logs/"
                     }
                 }
             },
@@ -314,12 +316,10 @@ with DAG(
         execution_role_arn=EMR_EXECUTION_ROLE_ARN,
         job_driver={
             "sparkSubmit": {
-                "entryPoint": (
-                    f"s3://{SCRIPTS_BUCKET}/spark-scripts/silver_to_gold_features.py"
-                ),
+                "entryPoint": (f"{SCRIPTS_LOCATION}/silver_to_gold_features.py"),
                 "entryPointArguments": [
-                    "--data-bucket",
-                    DATA_BUCKET,
+                    "--data-root",
+                    DATA_LAKE_ROOT,
                     "--silver-database",
                     GLUE_DB_SILVER,
                     "--gold-database",
@@ -341,7 +341,7 @@ with DAG(
         },
         configuration_overrides={
             "monitoringConfiguration": {
-                "s3MonitoringConfiguration": {"logUri": f"s3://{DATA_BUCKET}/emr-logs/"}
+                "s3MonitoringConfiguration": {"logUri": f"{DATA_LAKE_ROOT}/emr-logs/"}
             }
         },
     )

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -21,13 +21,13 @@ x-airflow-common: &airflow-common
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
     # ── Pipeline config (from Terraform outputs) ──
     # Replace these with your actual values after running terraform apply
-    DATA_BUCKET: "${DATA_BUCKET:-nyc-taxi-pipeline-data-lake-dev}"
-    SCRIPTS_BUCKET: "${SCRIPTS_BUCKET:-nyc-taxi-pipeline-scripts-dev}"
+    DATA_LAKE_ROOT: "${DATA_LAKE_ROOT:-s3://nateeatsrice-master-s3/data-lake}"
+    SCRIPTS_LOCATION: "${SCRIPTS_LOCATION:-s3://nateeatsrice-master-s3/scripts/data-pipeline}"
     EMR_APP_ID: "${EMR_APP_ID:-}"
     EMR_EXECUTION_ROLE_ARN: "${EMR_EXECUTION_ROLE_ARN:-}"
-    GLUE_DB_BRONZE: "${GLUE_DB_BRONZE:-nyc_taxi_pipeline_bronze_dev}"
-    GLUE_DB_SILVER: "${GLUE_DB_SILVER:-nyc_taxi_pipeline_silver_dev}"
-    GLUE_DB_GOLD: "${GLUE_DB_GOLD:-nyc_taxi_pipeline_gold_dev}"
+    GLUE_DB_BRONZE: "${GLUE_DB_BRONZE:-data_pipeline_bronze_dev}"
+    GLUE_DB_SILVER: "${GLUE_DB_SILVER:-data_pipeline_silver_dev}"
+    GLUE_DB_GOLD: "${GLUE_DB_GOLD:-data_pipeline_gold_dev}"
     AWS_REGION: "${AWS_REGION:-us-east-1}"
     # AWS credentials — mount your ~/.aws folder or set these
     AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID:-}"

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ environment variables (set by Terraform outputs) with sensible defaults.
 Usage:
     from src.config import Config
     config = Config()
-    print(config.DATA_BUCKET)
+    print(config.DATA_LAKE_ROOT)
 """
 
 import os
@@ -21,18 +21,18 @@ class Config:
 
     # AWS
     AWS_REGION: str = field(
-        default_factory=lambda: os.getenv("AWS_REGION", "us-east-1")
+        default_factory=lambda: os.getenv("AWS_REGION", "us-east-2")
     )
 
-    # S3 Buckets
-    DATA_BUCKET: str = field(
+    # S3 Locations (full URIs into the shared master bucket)
+    DATA_LAKE_ROOT: str = field(
         default_factory=lambda: os.getenv(
-            "DATA_BUCKET", "nyc-taxi-pipeline-data-lake-dev"
+            "DATA_LAKE_ROOT", "s3://nateeatsrice-master-s3/data-lake"
         )
     )
-    SCRIPTS_BUCKET: str = field(
+    SCRIPTS_LOCATION: str = field(
         default_factory=lambda: os.getenv(
-            "SCRIPTS_BUCKET", "nyc-taxi-pipeline-scripts-dev"
+            "SCRIPTS_LOCATION", "s3://nateeatsrice-master-s3/scripts/data-pipeline"
         )
     )
 
@@ -49,22 +49,18 @@ class Config:
 
     # Glue Databases
     GLUE_DB_BRONZE: str = field(
-        default_factory=lambda: os.getenv(
-            "GLUE_DB_BRONZE", "nyc_taxi_pipeline_bronze_dev"
-        )
+        default_factory=lambda: os.getenv("GLUE_DB_BRONZE", "data_pipeline_bronze_dev")
     )
     GLUE_DB_SILVER: str = field(
-        default_factory=lambda: os.getenv(
-            "GLUE_DB_SILVER", "nyc_taxi_pipeline_silver_dev"
-        )
+        default_factory=lambda: os.getenv("GLUE_DB_SILVER", "data_pipeline_silver_dev")
     )
     GLUE_DB_GOLD: str = field(
-        default_factory=lambda: os.getenv("GLUE_DB_GOLD", "nyc_taxi_pipeline_gold_dev")
+        default_factory=lambda: os.getenv("GLUE_DB_GOLD", "data_pipeline_gold_dev")
     )
 
     # Athena
     ATHENA_WORKGROUP: str = field(
-        default_factory=lambda: os.getenv("ATHENA_WORKGROUP", "nyc-taxi-pipeline-dev")
+        default_factory=lambda: os.getenv("ATHENA_WORKGROUP", "data-pipeline-dev")
     )
 
     # Data Source URLs
@@ -88,10 +84,22 @@ class Config:
             config.s3_path("bronze", "nyc_tlc", "yellow", 2025, 1)
             → "s3://bucket/bronze/nyc_tlc/yellow/year=2025/month=01/"
         """
-        path = f"s3://{self.DATA_BUCKET}/{layer}/{source}/{dataset}"
+        path = f"{self.DATA_LAKE_ROOT}/{layer}/{source}/{dataset}"
         if year and month:
             path += f"/year={year}/month={month:02d}"
         return path + "/"
+
+    @property
+    def data_bucket_name(self) -> str:
+        """Bare bucket name parsed from DATA_LAKE_ROOT (for boto3 calls)."""
+        return self.DATA_LAKE_ROOT.replace("s3://", "").split("/", 1)[0]
+
+    @property
+    def data_key_prefix(self) -> str:
+        """Key prefix under the bucket, e.g. 'data-lake' (no trailing slash)."""
+        no_scheme = self.DATA_LAKE_ROOT.replace("s3://", "").rstrip("/")
+        parts = no_scheme.split("/", 1)
+        return parts[1] if len(parts) > 1 else ""
 
     def get_latest_available_month(self) -> tuple[int, int]:
         """Return (year, month) of the most recent TLC data likely available."""

--- a/src/ingestion/noaa_weather_ingestion.py
+++ b/src/ingestion/noaa_weather_ingestion.py
@@ -185,15 +185,15 @@ def ingest_weather(
     }
 
     filename = f"nyc_weather_daily_{year}.parquet"
-    s3_key = f"{config.BRONZE_PREFIX}/noaa_weather/nyc_daily/year={year}/{filename}"
+    s3_key = f"{config.data_key_prefix}/{config.BRONZE_PREFIX}/noaa_weather/nyc_daily/year={year}/{filename}"
 
     try:
         # Check if already ingested
-        if skip_existing and _check_exists(s3_client, config.DATA_BUCKET, s3_key):
+        if skip_existing and _check_exists(s3_client, config.data_bucket_name, s3_key):
             logger.info(f"Weather {year} already ingested. Skipping.")
             result["skipped"] = True
             result["success"] = True
-            result["s3_uri"] = f"s3://{config.DATA_BUCKET}/{s3_key}"
+            result["s3_uri"] = f"s3://{config.data_bucket_name}/{s3_key}"
             return result
 
         # Download raw hourly data
@@ -208,11 +208,11 @@ def ingest_weather(
             local_path = Path(tmpdir) / filename
             daily_df.to_parquet(local_path, index=False, engine="pyarrow")
 
-            logger.info(f"Uploading to s3://{config.DATA_BUCKET}/{s3_key}")
-            s3_client.upload_file(str(local_path), config.DATA_BUCKET, s3_key)
+            logger.info(f"Uploading to s3://{config.data_bucket_name}/{s3_key}")
+            s3_client.upload_file(str(local_path), config.data_bucket_name, s3_key)
 
         result["success"] = True
-        result["s3_uri"] = f"s3://{config.DATA_BUCKET}/{s3_key}"
+        result["s3_uri"] = f"s3://{config.data_bucket_name}/{s3_key}"
         logger.info(f"Successfully ingested weather for {year}")
 
     except Exception as e:

--- a/src/ingestion/nyc_tlc_ingestion.py
+++ b/src/ingestion/nyc_tlc_ingestion.py
@@ -122,19 +122,19 @@ def ingest_yellow_taxi(
     filename = f"yellow_tripdata_{year}-{month:02d}.parquet"
     source_url = f"{config.NYC_TLC_BASE_URL}/{filename}"
     s3_key = (
-        f"{config.BRONZE_PREFIX}/nyc_tlc/yellow/"
+        f"{config.data_key_prefix}/{config.BRONZE_PREFIX}/nyc_tlc/yellow/"
         f"year={year}/month={month:02d}/{filename}"
     )
 
     try:
         # Check if already ingested
         if skip_existing and check_already_ingested(
-            s3_client, config.DATA_BUCKET, s3_key
+            s3_client, config.data_bucket_name, s3_key
         ):
             logger.info(f"Already ingested: {year}-{month:02d}. Skipping.")
             result["skipped"] = True
             result["success"] = True
-            result["s3_uri"] = f"s3://{config.DATA_BUCKET}/{s3_key}"
+            result["s3_uri"] = f"s3://{config.data_bucket_name}/{s3_key}"
             return result
 
         # Check if source exists
@@ -150,7 +150,9 @@ def ingest_yellow_taxi(
         with tempfile.TemporaryDirectory() as tmpdir:
             local_path = Path(tmpdir) / filename
             download_file(source_url, local_path)
-            s3_uri = upload_to_s3(s3_client, local_path, config.DATA_BUCKET, s3_key)
+            s3_uri = upload_to_s3(
+                s3_client, local_path, config.data_bucket_name, s3_key
+            )
 
         result["success"] = True
         result["s3_uri"] = s3_uri
@@ -185,18 +187,16 @@ def ingest_green_taxi(
 
     filename = f"green_tripdata_{year}-{month:02d}.parquet"
     source_url = f"{config.NYC_TLC_BASE_URL}/{filename}"
-    s3_key = (
-        f"{config.BRONZE_PREFIX}/nyc_tlc/green/year={year}/month={month:02d}/{filename}"
-    )
+    s3_key = f"{config.data_key_prefix}/{config.BRONZE_PREFIX}/nyc_tlc/green/year={year}/month={month:02d}/{filename}"
 
     try:
         if skip_existing and check_already_ingested(
-            s3_client, config.DATA_BUCKET, s3_key
+            s3_client, config.data_bucket_name, s3_key
         ):
             logger.info(f"Already ingested green {year}-{month:02d}. Skipping.")
             result["skipped"] = True
             result["success"] = True
-            result["s3_uri"] = f"s3://{config.DATA_BUCKET}/{s3_key}"
+            result["s3_uri"] = f"s3://{config.data_bucket_name}/{s3_key}"
             return result
 
         if not check_source_exists(source_url):
@@ -207,7 +207,9 @@ def ingest_green_taxi(
         with tempfile.TemporaryDirectory() as tmpdir:
             local_path = Path(tmpdir) / filename
             download_file(source_url, local_path)
-            s3_uri = upload_to_s3(s3_client, local_path, config.DATA_BUCKET, s3_key)
+            s3_uri = upload_to_s3(
+                s3_client, local_path, config.data_bucket_name, s3_key
+            )
 
         result["success"] = True
         result["s3_uri"] = s3_uri

--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -125,12 +125,22 @@ def check_s3_freshness(
 # ─── Composite Check Suites ─────────────────────────────────────────────────
 
 
+def _parse_data_root(data_root: str):
+    """Split an s3://bucket/base/prefix URI into (bucket, base_prefix)."""
+    no_scheme = data_root.replace("s3://", "").rstrip("/")
+    parts = no_scheme.split("/", 1)
+    bucket = parts[0]
+    base_prefix = (parts[1] + "/") if len(parts) > 1 else ""
+    return bucket, base_prefix
+
+
 def run_bronze_taxi_checks(
-    bucket: str, year: int, month: int, s3_client=None
+    data_root: str, year: int, month: int, s3_client=None
 ) -> list[CheckResult]:
     """Run all quality checks for bronze taxi data."""
     s3_client = s3_client or boto3.client("s3")
-    prefix = f"bronze/nyc_tlc/yellow/year={year}/month={month:02d}/"
+    bucket, base = _parse_data_root(data_root)
+    prefix = f"{base}bronze/nyc_tlc/yellow/year={year}/month={month:02d}/"
 
     results = [
         check_s3_object_exists(s3_client, bucket, prefix),
@@ -141,11 +151,12 @@ def run_bronze_taxi_checks(
 
 
 def run_silver_taxi_checks(
-    bucket: str, year: int, month: int, s3_client=None
+    data_root: str, year: int, month: int, s3_client=None
 ) -> list[CheckResult]:
     """Run all quality checks for silver taxi data."""
     s3_client = s3_client or boto3.client("s3")
-    prefix = f"silver/nyc_tlc/yellow/year={year}/month={month:02d}/"
+    bucket, base = _parse_data_root(data_root)
+    prefix = f"{base}silver/nyc_tlc/yellow/year={year}/month={month:02d}/"
 
     results = [
         check_s3_object_exists(s3_client, bucket, prefix),
@@ -156,14 +167,15 @@ def run_silver_taxi_checks(
 
 
 def run_gold_checks(
-    bucket: str, year: int, month: int, s3_client=None
+    data_root: str, year: int, month: int, s3_client=None
 ) -> list[CheckResult]:
     """Run all quality checks for gold feature tables."""
     s3_client = s3_client or boto3.client("s3")
+    bucket, base = _parse_data_root(data_root)
 
     results = []
     for table in ["trip_weather_daily", "location_hourly_features"]:
-        prefix = f"gold/features/{table}/year={year}/month={month:02d}/"
+        prefix = f"{base}gold/features/{table}/year={year}/month={month:02d}/"
         results.extend(
             [
                 check_s3_object_exists(s3_client, bucket, prefix),

--- a/src/transformation/bronze_to_silver_taxi.py
+++ b/src/transformation/bronze_to_silver_taxi.py
@@ -14,7 +14,7 @@ passed in the Airflow DAG.
 
 Usage (local testing with spark-submit):
     spark-submit src/transformation/bronze_to_silver_taxi.py \
-        --data-bucket my-bucket \
+        --data-root s3://bucket/data-lake \
         --year 2024 --month 12 \
         --glue-database nyc_taxi_pipeline_silver_dev
 """
@@ -222,7 +222,7 @@ def write_silver(df, output_path: str, glue_database: str, table_name: str):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data-bucket", required=True)
+    parser.add_argument("--data-root", required=True)
     parser.add_argument("--year", type=int, required=True)
     parser.add_argument("--month", type=int, required=True)
     parser.add_argument("--glue-database", required=True)
@@ -233,7 +233,7 @@ def main():
     try:
         # Read bronze
         bronze_path = (
-            f"s3://{args.data_bucket}/bronze/nyc_tlc/yellow/"
+            f"{args.data_root}/bronze/nyc_tlc/yellow/"
             f"year={args.year}/month={args.month:02d}/"
         )
         df = read_bronze(spark, bronze_path)
@@ -242,7 +242,7 @@ def main():
         df_clean = clean_yellow_taxi(df)
 
         # Write silver
-        silver_path = f"s3://{args.data_bucket}/silver/nyc_tlc/yellow/"
+        silver_path = f"{args.data_root}/silver/nyc_tlc/yellow/"
         write_silver(df_clean, silver_path, args.glue_database, "yellow_taxi_trips")
 
         logger.info("Bronze → Silver transformation complete!")

--- a/src/transformation/bronze_to_silver_weather.py
+++ b/src/transformation/bronze_to_silver_weather.py
@@ -109,7 +109,7 @@ def clean_weather(df):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data-bucket", required=True)
+    parser.add_argument("--data-root", required=True)
     parser.add_argument("--year", type=int, required=True)
     parser.add_argument("--glue-database", required=True)
     args = parser.parse_args()
@@ -118,7 +118,7 @@ def main():
 
     try:
         bronze_path = (
-            f"s3://{args.data_bucket}/bronze/noaa_weather/nyc_daily/year={args.year}/"
+            f"{args.data_root}/bronze/noaa_weather/nyc_daily/year={args.year}/"
         )
         logger.info(f"Reading bronze weather from {bronze_path}")
         df = spark.read.parquet(bronze_path)
@@ -126,7 +126,7 @@ def main():
 
         df_clean = clean_weather(df)
 
-        silver_path = f"s3://{args.data_bucket}/silver/noaa_weather/nyc_daily/"
+        silver_path = f"{args.data_root}/silver/noaa_weather/nyc_daily/"
         logger.info(f"Writing silver weather to {silver_path}")
 
         (

--- a/src/transformation/silver_to_gold_features.py
+++ b/src/transformation/silver_to_gold_features.py
@@ -36,7 +36,7 @@ def create_spark_session() -> SparkSession:
     )
 
 
-def build_trip_weather_daily(spark, data_bucket: str, silver_db: str):
+def build_trip_weather_daily(spark, data_root: str, silver_db: str):
     """
     Gold Table 1: trip_weather_daily
     Joins daily taxi aggregates with weather to answer:
@@ -129,7 +129,7 @@ def build_trip_weather_daily(spark, data_bucket: str, silver_db: str):
     return features
 
 
-def build_location_hourly_features(spark, data_bucket: str, silver_db: str):
+def build_location_hourly_features(spark, data_root: str, silver_db: str):
     """
     Gold Table 2: location_hourly_features
     Per-zone, per-hour aggregations for demand prediction.
@@ -176,7 +176,7 @@ def build_location_hourly_features(spark, data_bucket: str, silver_db: str):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data-bucket", required=True)
+    parser.add_argument("--data-root", required=True)
     parser.add_argument("--silver-database", required=True)
     parser.add_argument("--gold-database", required=True)
     parser.add_argument("--year", type=int, required=True)
@@ -188,10 +188,10 @@ def main():
     try:
         # ── Gold Table 1: Trip + Weather Daily ──
         trip_weather = build_trip_weather_daily(
-            spark, args.data_bucket, args.silver_database
+            spark, args.data_root, args.silver_database
         )
 
-        gold_path_1 = f"s3://{args.data_bucket}/gold/features/trip_weather_daily/"
+        gold_path_1 = f"{args.data_root}/gold/features/trip_weather_daily/"
         (
             trip_weather.write.mode("overwrite")
             .partitionBy("year", "month")
@@ -203,10 +203,10 @@ def main():
 
         # ── Gold Table 2: Location Hourly Features ──
         location_features = build_location_hourly_features(
-            spark, args.data_bucket, args.silver_database
+            spark, args.data_root, args.silver_database
         )
 
-        gold_path_2 = f"s3://{args.data_bucket}/gold/features/location_hourly_features/"
+        gold_path_2 = f"{args.data_root}/gold/features/location_hourly_features/"
         (
             location_features.write.mode("overwrite")
             .partitionBy("year", "month")


### PR DESCRIPTION
Complete the master-bucket migration across all pipeline code so paths resolve to s3://<master-bucket>/data-lake/... consistently.

- Spark scripts: --data-bucket -> --data-root (full URI)
- DAG: DATA_LAKE_ROOT/SCRIPTS_LOCATION env + --data-root job args
- ingestion: write to data-lake/ prefix via config.data_bucket_name
- data quality: parse URI into bucket + prefix
- config: add data_bucket_name / data_key_prefix derived props
- docker-compose, .env.example, Makefile deploy-scripts updated

Closes #28, Closes #29, Closes #30