### PR TITLE
Add bronze + silver weather data quality checks

### DIFF
--- a/airflow/dags/nyc_taxi_pipeline_dag.py
+++ b/airflow/dags/nyc_taxi_pipeline_dag.py
@@ -147,8 +147,10 @@ def run_quality_checks(check_type: str, **context):
     from quality.data_quality_checks import (
         evaluate_results,
         run_bronze_taxi_checks,
+        run_bronze_weather_checks,
         run_gold_checks,
         run_silver_taxi_checks,
+        run_silver_weather_checks,
     )
 
     ti = context["ti"]
@@ -158,6 +160,8 @@ def run_quality_checks(check_type: str, **context):
     check_fns = {
         "bronze_taxi": run_bronze_taxi_checks,
         "silver_taxi": run_silver_taxi_checks,
+        "bronze_weather": run_bronze_weather_checks,
+        "silver_weather": run_silver_weather_checks,
         "gold": run_gold_checks,
     }
 
@@ -223,11 +227,17 @@ with DAG(
         )
 
     # ── Step 3: Bronze quality checks ──
-    check_bronze = PythonOperator(
-        task_id="check_bronze_quality",
-        python_callable=run_quality_checks,
-        op_kwargs={"check_type": "bronze_taxi"},
-    )
+    with TaskGroup("bronze_checks") as bronze_check_group:
+        check_bronze = PythonOperator(
+            task_id="check_bronze_quality",
+            python_callable=run_quality_checks,
+            op_kwargs={"check_type": "bronze_taxi"},
+        )
+        check_bronze_weather = PythonOperator(
+            task_id="check_bronze_weather_quality",
+            python_callable=run_quality_checks,
+            op_kwargs={"check_type": "bronze_weather"},
+        )
 
     # ── Step 4: Bronze → Silver (EMR Serverless) ──
     # These use Airflow's EMR Serverless operators to submit and monitor jobs.
@@ -303,11 +313,17 @@ with DAG(
         )
 
     # ── Step 5: Silver quality checks ──
-    check_silver = PythonOperator(
-        task_id="check_silver_quality",
-        python_callable=run_quality_checks,
-        op_kwargs={"check_type": "silver_taxi"},
-    )
+    with TaskGroup("silver_checks") as silver_check_group:
+        check_silver = PythonOperator(
+            task_id="check_silver_quality",
+            python_callable=run_quality_checks,
+            op_kwargs={"check_type": "silver_taxi"},
+        )
+        check_silver_weather = PythonOperator(
+            task_id="check_silver_weather_quality",
+            python_callable=run_quality_checks,
+            op_kwargs={"check_type": "silver_weather"},
+        )
 
     # ── Step 6: Silver → Gold (EMR Serverless) ──
     s2g_features = EmrServerlessStartJobOperator(
@@ -360,13 +376,12 @@ with DAG(
     #     → check_bronze → [transform_taxi, transform_weather]
     #     → check_silver → build_gold_features → check_gold
 
-    (
-        determine_period
-        >> upload_scripts
-        >> ingestion_group
-        >> check_bronze
-        >> b2s_group
-        >> check_silver
-        >> s2g_features
-        >> check_gold
-    )
+    determine_period >> upload_scripts >> ingestion_group
+
+    # Bronze checks (taxi + weather) run in parallel, both gate the transform
+    ingestion_group >> bronze_check_group >> b2s_group
+
+    # Silver checks (taxi + weather) run in parallel, both gate gold
+    b2s_group >> silver_check_group >> s2g_features
+
+    s2g_features >> check_gold

--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -179,6 +179,28 @@ def run_bronze_taxi_checks(
     return results
 
 
+def run_bronze_weather_checks(
+    data_root: str, year: int, month: int, s3_client=None
+) -> list[CheckResult]:
+    """Run quality checks for bronze weather data (annual NOAA file).
+
+    month is accepted for signature consistency with the other suites but
+    is unused — NOAA bronze is a single annual file, not month-partitioned.
+    """
+    s3_client = s3_client or boto3.client("s3")
+    bucket, base = _parse_data_root(data_root)
+    prefix = f"{base}bronze/noaa_weather/nyc_daily/year={year}/"
+
+    # Weather files are small (one annual parquet of daily records), so the
+    # size/count thresholds are much smaller than taxi.
+    results = [
+        check_s3_object_exists(s3_client, bucket, prefix),
+        check_s3_file_size(s3_client, bucket, prefix, min_bytes=1000),
+        check_s3_file_count(s3_client, bucket, prefix, min_files=1, max_files=5),
+    ]
+    return results
+
+
 def run_silver_taxi_checks(
     data_root: str, year: int, month: int, s3_client=None
 ) -> list[CheckResult]:
@@ -192,6 +214,28 @@ def run_silver_taxi_checks(
         check_s3_object_exists(s3_client, bucket, prefix),
         check_s3_file_size(s3_client, bucket, prefix, min_bytes=5_000_000),
         check_s3_file_count(s3_client, bucket, prefix, min_files=1, max_files=200),
+        check_no_unexpected_partitions(s3_client, bucket, table_base, year),
+    ]
+    return results
+
+
+def run_silver_weather_checks(
+    data_root: str, year: int, month: int, s3_client=None
+) -> list[CheckResult]:
+    """Run quality checks for silver weather data.
+
+    month is accepted for signature consistency but unused — the annual
+    NOAA file is processed per-year and partitioned across all 12 months.
+    """
+    s3_client = s3_client or boto3.client("s3")
+    bucket, base = _parse_data_root(data_root)
+    prefix = f"{base}silver/noaa_weather/nyc_daily/year={year}/"
+    table_base = f"{base}silver/noaa_weather/nyc_daily/"
+
+    results = [
+        check_s3_object_exists(s3_client, bucket, prefix),
+        check_s3_file_size(s3_client, bucket, prefix, min_bytes=1000),
+        check_s3_file_count(s3_client, bucket, prefix, min_files=1, max_files=50),
         check_no_unexpected_partitions(s3_client, bucket, table_base, year),
     ]
     return results
@@ -239,7 +283,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--check",
         required=True,
-        choices=["bronze_taxi", "silver_taxi", "gold"],
+        choices=[
+            "bronze_taxi",
+            "silver_taxi",
+            "bronze_weather",
+            "silver_weather",
+            "gold",
+        ],
     )
     parser.add_argument("--bucket", required=True)
     parser.add_argument("--year", type=int, required=True)
@@ -249,6 +299,8 @@ if __name__ == "__main__":
     check_fns = {
         "bronze_taxi": run_bronze_taxi_checks,
         "silver_taxi": run_silver_taxi_checks,
+        "bronze_weather": run_bronze_weather_checks,
+        "silver_weather": run_silver_weather_checks,
         "gold": run_gold_checks,
     }
 

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -113,8 +113,11 @@ class TestAirflowDag:
             # Check key tasks exist
             assert "determine_processing_period" in task_ids
             assert "upload_spark_scripts" in task_ids
-            assert "check_bronze_quality" in task_ids
-            assert "check_silver_quality" in task_ids
+            # Quality-check tasks are namespaced under their TaskGroups
+            assert "bronze_checks.check_bronze_quality" in task_ids
+            assert "bronze_checks.check_bronze_weather_quality" in task_ids
+            assert "silver_checks.check_silver_quality" in task_ids
+            assert "silver_checks.check_silver_weather_quality" in task_ids
             assert "build_gold_features" in task_ids
             assert "check_gold_quality" in task_ids
 


### PR DESCRIPTION
Adds basic data quality checks for the weather path (bronze + silver), which previously had none — only the taxi path was validated. The DAG ran bronze and silver quality checks but both only called taxi check functions. A bad or empty weather ingest/transform wouldn't be caught until the gold join broke. This closes that gap for consistency.

run_bronze_weather_checks / run_silver_weather_checks mirroring the taxi suites, with thresholds appropriate for weather (small annual NOAA files vs large monthly taxi files)
Silver weather gets the no_unexpected_partitions guard added in #34
Two new DAG tasks, grouped with the taxi checks in TaskGroups, running in parallel at each stage
CLI + dispatch updated for the new check types

Bare-bones existence/size/count/partition checks. Deeper completeness + accuracy checks (reading actual data via Athena) are tracked in [the completeness/accuracy issue].
Closes #37