### PR TITLE
Align CI region to us-east-2 and fix deprecated datetime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           uv run pytest tests/test_ingestion.py tests/test_quality_and_dag.py \
             -v --tb=short -x
         env:
-          AWS_DEFAULT_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-2
           AWS_ACCESS_KEY_ID: testing
           AWS_SECRET_ACCESS_KEY: testing
 
@@ -103,7 +103,7 @@ jobs:
         run: |
           uv run pytest tests/test_transformations.py -v --tb=short -x
         env:
-          AWS_DEFAULT_REGION: us-east-1
+          AWS_DEFAULT_REGION: us-east-2
           AWS_ACCESS_KEY_ID: testing
           AWS_SECRET_ACCESS_KEY: testing
 

--- a/airflow/.env.example
+++ b/airflow/.env.example
@@ -8,7 +8,7 @@ EMR_EXECUTION_ROLE_ARN=arn:aws:iam::123456789012:role/nyc-taxi-pipeline-emr-serv
 GLUE_DB_BRONZE=data_pipeline_bronze_dev
 GLUE_DB_SILVER=data_pipeline_silver_dev
 GLUE_DB_GOLD=data_pipeline_gold_dev
-AWS_REGION=us-east-1
+AWS_REGION=us-east-2
 
 # Option 1: Set AWS credentials directly (not recommended for production)
 # AWS_ACCESS_KEY_ID=

--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,7 @@ Usage:
 
 import os
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 
 
 @dataclass
@@ -103,7 +103,7 @@ class Config:
 
     def get_latest_available_month(self) -> tuple[int, int]:
         """Return (year, month) of the most recent TLC data likely available."""
-        now = datetime.utcnow()
+        now = datetime.now(UTC)  # depreciated: now = datetime.utcnow()
         # Subtract publication lag
         month = now.month - self.TLC_PUBLICATION_LAG_MONTHS
         year = now.year


### PR DESCRIPTION
1. CI region alignment- the test and test-spark jobs ran in us-east-1, but all real infra (Terraform backends, config defaults) is in us-east-2. Aligned both jobs to us-east-2 so CI matches reality. Also fixed the stale us-east-1 in airflow/.env.example.
2. Deprecated datetime fix - replaced datetime.utcnow() (deprecated in Python 3.12+) with datetime.now(timezone.utc) in config.py, and added timezone to the import.