### PR TITLE
Add silver_to_gold aggregation tests

### DIFF
--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -366,3 +366,169 @@ class TestBronzeToSilverWeather:
         result = clean_weather(df, 2024)
         years = {row["year"] for row in result.collect()}
         assert years == {2024}
+
+
+@pytest.mark.skipif(not SPARK_AVAILABLE, reason="PySpark not installed")
+class TestSilverToGold:
+    """Tests for gold feature-table aggregation math."""
+
+    def _register_silver_tables(self, spark, taxi_rows, weather_rows, db):
+        """Create the silver catalog tables the gold builders read from."""
+        spark.sql(f"CREATE DATABASE IF NOT EXISTS {db}")
+        spark.createDataFrame(taxi_rows).write.mode("overwrite").saveAsTable(
+            f"{db}.yellow_taxi_trips"
+        )
+        spark.createDataFrame(weather_rows).write.mode("overwrite").saveAsTable(
+            f"{db}.nyc_weather_daily"
+        )
+
+    def test_trip_weather_daily_exact_aggregates(self, spark):
+        """Daily trip aggregates should compute exact known values."""
+        from transformation.silver_to_gold_features import build_trip_weather_daily
+
+        taxi_rows = [
+            {
+                "pickup_date": "2024-12-15",
+                "pickup_hour": 8,
+                "pickup_location_id": 100,
+                "dropoff_location_id": 200,
+                "passenger_count": 2,
+                "trip_distance": 3.0,
+                "trip_duration_minutes": 10.0,
+                "fare_amount": 10.0,
+                "tip_amount": 2.0,
+                "total_amount": 14.0,
+                "payment_type": 1,
+            },
+            {
+                "pickup_date": "2024-12-15",
+                "pickup_hour": 8,
+                "pickup_location_id": 101,
+                "dropoff_location_id": 201,
+                "passenger_count": 1,
+                "trip_distance": 5.0,
+                "trip_duration_minutes": 20.0,
+                "fare_amount": 20.0,
+                "tip_amount": 4.0,
+                "total_amount": 26.0,
+                "payment_type": 2,
+            },
+            {
+                "pickup_date": "2024-12-15",
+                "pickup_hour": 17,
+                "pickup_location_id": 102,
+                "dropoff_location_id": 202,
+                "passenger_count": 3,
+                "trip_distance": 1.0,
+                "trip_duration_minutes": 6.0,
+                "fare_amount": 6.0,
+                "tip_amount": 0.0,
+                "total_amount": 6.0,
+                "payment_type": 1,
+            },
+        ]
+        weather_rows = [
+            {
+                "date": "2024-12-15",
+                "temp_avg_celsius": 5.0,
+                "temp_avg_fahrenheit": 41.0,
+                "temp_min_celsius": 2.0,
+                "temp_max_celsius": 8.0,
+                "precip_total_mm": 0.0,
+                "wind_avg_ms": 3.0,
+                "is_rainy": False,
+                "is_snowy": False,
+            },
+        ]
+
+        self._register_silver_tables(spark, taxi_rows, weather_rows, "silver_g2g_a")
+        result = build_trip_weather_daily(
+            spark, "s3://unused", "silver_g2g_a", 2024, 12
+        )
+        row = result.first()
+
+        assert row["total_trips"] == 3
+        assert row["total_passengers"] == 6
+        assert row["avg_fare"] == pytest.approx(12.0, abs=0.01)  # (10+20+6)/3
+        assert row["total_revenue"] == pytest.approx(46.0, abs=0.01)  # 14+26+6
+        assert row["credit_card_trips"] == 2  # payment_type 1, two trips
+        assert row["cash_trips"] == 1
+        assert row["morning_rush_trips"] == 2  # hour 8 is within 6-9
+        assert row["evening_rush_trips"] == 1  # hour 17 is within 16-19
+
+    def test_location_hourly_exact_aggregates(self, spark):
+        """Per date+hour+zone aggregates should compute exact known values."""
+        from transformation.silver_to_gold_features import (
+            build_location_hourly_features,
+        )
+
+        # All on the same date and hour. Two trips in zone 100, one in
+        # zone 999. The grain is (date, hour, location), so each zone is
+        # its own group here.
+        taxi_rows = [
+            {
+                "pickup_date": "2024-12-15",
+                "pickup_hour": 8,
+                "pickup_location_id": 100,
+                "dropoff_location_id": 200,
+                "passenger_count": 1,
+                "trip_distance": 2.0,
+                "trip_duration_minutes": 10.0,
+                "fare_amount": 10.0,
+                "tip_amount": 2.0,
+                "total_amount": 12.0,
+                "payment_type": 1,
+            },
+            {
+                "pickup_date": "2024-12-15",
+                "pickup_hour": 8,
+                "pickup_location_id": 100,
+                "dropoff_location_id": 201,
+                "passenger_count": 1,
+                "trip_distance": 4.0,
+                "trip_duration_minutes": 20.0,
+                "fare_amount": 20.0,
+                "tip_amount": 4.0,
+                "total_amount": 24.0,
+                "payment_type": 1,
+            },
+            {
+                "pickup_date": "2024-12-15",
+                "pickup_hour": 8,
+                "pickup_location_id": 999,
+                "dropoff_location_id": 200,
+                "passenger_count": 1,
+                "trip_distance": 1.0,
+                "trip_duration_minutes": 5.0,
+                "fare_amount": 5.0,
+                "tip_amount": 1.0,
+                "total_amount": 6.0,
+                "payment_type": 1,
+            },
+        ]
+        weather_rows = [
+            {
+                "date": "2024-12-15",
+                "temp_avg_celsius": 5.0,
+                "temp_avg_fahrenheit": 41.0,
+                "temp_min_celsius": 2.0,
+                "temp_max_celsius": 8.0,
+                "precip_total_mm": 0.0,
+                "wind_avg_ms": 3.0,
+                "is_rainy": False,
+                "is_snowy": False,
+            },
+        ]
+
+        self._register_silver_tables(spark, taxi_rows, weather_rows, "silver_g2g_b")
+        result = build_location_hourly_features(
+            spark, "s3://unused", "silver_g2g_b", 2024, 12
+        )
+        # Key by location; safe here because all rows share one date+hour.
+        rows = {row["pickup_location_id"]: row for row in result.collect()}
+
+        assert rows[100]["trip_count"] == 2
+        assert rows[100]["avg_distance"] == pytest.approx(3.0, abs=0.01)  # (2+4)/2
+        assert rows[100]["total_revenue"] == pytest.approx(36.0, abs=0.01)  # 12+24
+        assert rows[100]["unique_destinations"] == 2  # zones 200, 201
+        assert rows[999]["trip_count"] == 1

--- a/tests/testing_philosophy.md
+++ b/tests/testing_philosophy.md
@@ -1,0 +1,83 @@
+# Testing Philosophy
+ 
+This document explains what we test in this pipeline, what we do not, and
+why. The goal is a small suite of tests that each protect something real.
+A test that cannot fail for a meaningful reason is worse than no test: it
+costs maintenance and gives false confidence.
+ 
+## The four rules
+ 
+### 1. Test business logic exhaustively
+ 
+Any code that parses, cleans, transforms, or computes is where bugs hide,
+so this is where coverage goes. Parsing functions, cleaning rules,
+aggregation math, and quality check thresholds all get tested against real
+inputs with known outputs.
+ 
+Example from this repo: `clean_weather` is tested for temperature range
+validation, single day gap interpolation, the `is_snowy` rule (precip over
+0.5mm AND temp at or below 1.0C), and the year filter. The gold
+aggregation tests construct a small known input and assert exact values
+(three trips, total revenue exactly 46.0), so a broken aggregate shows up
+as an obvious wrong number.
+ 
+### 2. One contract test per external boundary
+ 
+Where our code meets the outside world (the internet, S3, the Airflow
+scheduler) we keep exactly one test proving the connection behaves. One,
+not three. More tests on the same boundary add maintenance cost without
+catching anything new.
+ 
+Example from this repo: source availability is covered by a single test
+that confirms a 404 returns False (the branch that drives skip this
+month). Idempotency is covered by one skip when already exists test. The
+DAG has one parses without error test.
+ 
+### 3. Delete mock-echo tests
+ 
+A mock is a stand in for something slow or external. Using one is fine. The
+problem is a test that sets a mock to return a value and then only checks
+it got that value back. Such a test exercises no code of ours. It cannot
+fail, so it cannot warn us.
+ 
+Example from this repo: a removed test set a fake S3 client to not raise an
+error, then asserted the function returned True. It tested the fake, not
+our logic. The same function is still covered for real by the idempotency
+contract test, which runs actual branching.
+ 
+### 4. Do not test other people's tools
+ 
+We do not test that boto3 talks to S3, that requests handles HTTP, or that
+Spark configures a session. Those libraries test themselves. Re-testing
+them is like checking the wall outlet works before plugging in a lamp.
+ 
+Example from this repo: a removed test checked that `requests.head`
+returning an exception was handled. That is the HTTP library's behavior,
+not ours.
+ 
+## What we deliberately do not test, and why
+ 
+**boto3 and S3 plumbing.** Covered by AWS and boto3. We test our threshold
+logic (does the size check correctly sum file sizes and compare), not the
+S3 call itself.
+ 
+**Spark session configuration.** We test the transform logic that runs
+inside a session, not that the session starts with the right config.
+ 
+**The mechanics of mocks.** If an assertion only confirms a mock returned
+its configured value, it gets deleted.
+ 
+**Duplicate boundary cases.** Once one contract test proves a boundary
+works, extra variations on the same boundary are removed.
+ 
+**PySpark transforms run locally.** These tests require Spark, which is not
+installed on every dev machine. They skip locally and run on CI, where
+Spark and Java are present. A local skip is expected, not a failure.
+ 
+## How to add a test
+ 
+Before writing a test, ask which rule it serves. If it tests our logic
+(rule 1) or proves a boundary once (rule 2), write it. If it only echoes a
+mock (rule 3) or tests a library we do not own (rule 4), do not. Match the
+existing style: class based grouping, a docstring stating the behavior
+under test, and assertions on exact values where possible.


### PR DESCRIPTION
Adds exact-value tests for both gold feature builders. Part of the
test-suite changes

### New tests
- **trip_weather_daily** — constructs three known trips and asserts
  exact aggregates: total trips, total passengers, avg fare (12.0),
  total revenue (46.0), credit-card vs cash splits, and morning/evening
  rush-hour counts.
- **location_hourly_features** — constructs trips across two zones and
  asserts per-group trip count, avg distance, total revenue, and unique
  destination count.

Both use small hand-built inputs with arithmetic chosen so a broken
aggregate shows up as an obvious wrong number.

### Testing
Skips locally (no JVM on dev machine) — runs on CI.