### PR TITLE
Add quality-check test coverage

### DIFF
--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -75,6 +75,103 @@ class TestDataQualityChecks:
         ]
         assert evaluate_results(results) is False
 
+    def test_s3_freshness_recent_passes(self):
+        """Recent data (within max_age) should pass the freshness check."""
+        from datetime import UTC, datetime, timedelta
+
+        from quality.data_quality_checks import check_s3_freshness
+
+        recent = datetime.now(UTC) - timedelta(hours=1)
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [{"Key": "silver/f.parquet", "LastModified": recent}]
+        }
+        result = check_s3_freshness(mock_s3, "bucket", "silver/", max_age_hours=48)
+        assert result.passed is True
+
+    def test_s3_freshness_stale_fails(self):
+        """Data older than max_age should fail the freshness check."""
+        from datetime import UTC, datetime, timedelta
+
+        from quality.data_quality_checks import check_s3_freshness
+
+        stale = datetime.now(UTC) - timedelta(hours=100)
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [{"Key": "silver/f.parquet", "LastModified": stale}]
+        }
+        result = check_s3_freshness(mock_s3, "bucket", "silver/", max_age_hours=48)
+        assert result.passed is False
+
+    def test_s3_freshness_empty_prefix_fails(self):
+        """A prefix with no objects should fail (nothing was written)."""
+        from quality.data_quality_checks import check_s3_freshness
+
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {}  # no "Contents" key
+        result = check_s3_freshness(mock_s3, "bucket", "silver/", max_age_hours=48)
+        assert result.passed is False
+
+    def test_no_unexpected_partitions_clean_year_passes(self):
+        """Only the expected year present should pass."""
+        from quality.data_quality_checks import check_no_unexpected_partitions
+
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "CommonPrefixes": [
+                {"Prefix": "silver/yellow/year=2024/"},
+            ]
+        }
+        result = check_no_unexpected_partitions(
+            mock_s3, "bucket", "silver/yellow/", expected_year=2024
+        )
+        assert result.passed is True
+
+    def test_no_unexpected_partitions_stray_year_fails(self):
+        """A stray year alongside the expected one should fail."""
+        from quality.data_quality_checks import check_no_unexpected_partitions
+
+        # Mirrors the real bug: a stray 2002 partition leaking into the
+        # table path next to the expected 2024.
+        mock_s3 = MagicMock()
+        mock_s3.list_objects_v2.return_value = {
+            "CommonPrefixes": [
+                {"Prefix": "silver/yellow/year=2024/"},
+                {"Prefix": "silver/yellow/year=2002/"},
+            ]
+        }
+        result = check_no_unexpected_partitions(
+            mock_s3, "bucket", "silver/yellow/", expected_year=2024
+        )
+        assert result.passed is False
+
+
+class TestParseDataRoot:
+    """Tests for the _parse_data_root URI helper."""
+
+    def test_bucket_only(self):
+        """A bucket-only URI should yield an empty prefix."""
+        from quality.data_quality_checks import _parse_data_root
+
+        assert _parse_data_root("s3://my-bucket") == ("my-bucket", "")
+
+    def test_bucket_with_prefix(self):
+        """A bucket+prefix URI should keep the prefix with a trailing slash."""
+        from quality.data_quality_checks import _parse_data_root
+
+        bucket, prefix = _parse_data_root("s3://my-bucket/silver/yellow")
+        assert bucket == "my-bucket"
+        assert prefix == "silver/yellow/"
+
+    def test_trailing_slash_normalized(self):
+        """A trailing slash on the input should not double up."""
+        from quality.data_quality_checks import _parse_data_root
+
+        assert _parse_data_root("s3://my-bucket/silver/") == (
+            "my-bucket",
+            "silver/",
+        )
+
 
 class TestAirflowDag:
     """Validate Airflow DAG structure without running it."""


### PR DESCRIPTION
Adds coverage for three quality-layer functions. Final piece of the
test suite changes

### New tests
- **check_s3_freshness** recent data passes, stale data (older than
  max_age_hours) fails, empty prefix fails.
- **check_no_unexpected_partitions** clean year passes; a stray year
  alongside the expected one fails. Mirrors the real stray-partition
  issue found in S3 (#34).
- **_parse_data_root** bucket-only, bucket+prefix, and trailing-slash
  inputs all normalize to the correct (bucket, prefix) shape.

### Testing
Run locally (no Spark needed) — verified passing on the dev machine,
8 tests green. No skips.

Closes #53 