### PR TITLE
Feat/tier2 dq severity

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -63,6 +63,13 @@ class Config:
         default_factory=lambda: os.getenv("ATHENA_WORKGROUP", "data-pipeline-dev")
     )
 
+    ATHENA_OUTPUT_LOCATION: str = field(
+        default_factory=lambda: os.getenv(
+            "ATHENA_OUTPUT_LOCATION",
+            "s3://nateeatsrice-master-s3/athena-results/",
+        )
+    )
+
     # Data Source URLs
     NYC_TLC_BASE_URL: str = "https://d37ci6vzurychx.cloudfront.net/trip-data"
     NOAA_BASE_URL: str = "https://www.ncei.noaa.gov/data/global-hourly/access"

--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -16,12 +16,13 @@ Usage:
 import argparse
 import logging
 import sys
+import time
 from dataclasses import dataclass
 from datetime import UTC
 
 import boto3
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO)  # suppress debug logs to console
 logger = logging.getLogger("data_quality")
 
 
@@ -34,12 +35,140 @@ class CheckResult:
     message: str
     metric_value: float = None
     threshold: float = None
+    # "error" blocks the pipeline; "warn" logs but does not fail it.
+    # Defaults to "error" so existing checks keep their blocking behavior.
+    severity: str = "error"
+
+
+# ─── Helper Function ────────────────────────────────────────────────────────
+
+
+def _parse_data_root(data_root: str) -> tuple:
+    """Split an s3://bucket/base/prefix URI into (bucket, base_prefix).
+    "s3://my-bucket/silver/yellow/" -> ("my-bucket", "silver/yellow/")"""
+    no_scheme = data_root.replace("s3://", "").rstrip("/")
+    parts = no_scheme.split("/", 1)
+    bucket = parts[0]
+    base_prefix = (parts[1] + "/") if len(parts) > 1 else ""
+    return bucket, base_prefix
+
+
+# ─── Athena Helper (Tier 2 content checks) ──────────────────────────────────
+
+# Polling tuning. Athena queries are asynchronous: we start one, then poll
+# its status until it finishes. Backoff keeps us from hammering the API on
+# slow queries, and the timeout stops us looping forever on a stuck query.
+_ATHENA_POLL_INITIAL_SEC = 1.0  # first wait between status checks
+_ATHENA_POLL_MAX_SEC = 10.0  # cap per-wait so backoff doesn't grow unbounded
+_ATHENA_TIMEOUT_SEC = 300.0  # 5 min: generous for a monthly aggregate query
+
+
+def run_athena_query(
+    athena_client,
+    query: str,
+    database: str,
+    workgroup: str,
+    output_location: str,
+) -> list[dict]:
+    """Run an Athena query and return its rows as a list of dicts.
+
+    Athena is asynchronous, so this:
+      1. starts the query (start_query_execution),
+      2. polls its status with exponential backoff until it finishes,
+      3. on success, fetches and parses the result rows.
+
+    Returns a list of {column_name: value} dicts (all values are strings,
+    as Athena returns them; callers cast as needed). Raises RuntimeError
+    if the query fails, is cancelled, or exceeds the timeout.
+    """
+    start = athena_client.start_query_execution(
+        QueryString=query,
+        QueryExecutionContext={"Database": database},
+        WorkGroup=workgroup,
+        ResultConfiguration={"OutputLocation": output_location},
+    )
+    query_id = start["QueryExecutionId"]
+
+    # Poll until the query reaches a terminal state or we time out.
+    waited = 0.0
+    delay = _ATHENA_POLL_INITIAL_SEC
+    while True:
+        info = athena_client.get_query_execution(QueryExecutionId=query_id)
+        state = info["QueryExecution"]["Status"]["State"]
+        if state == "SUCCEEDED":
+            break
+        if state in ("FAILED", "CANCELLED"):
+            reason = info["QueryExecution"]["Status"].get(
+                "StateChangeReason", "no reason given"
+            )
+            raise RuntimeError(f"Athena query {state}: {reason}")
+        if waited >= _ATHENA_TIMEOUT_SEC:
+            raise RuntimeError(
+                f"Athena query timed out after {_ATHENA_TIMEOUT_SEC:.0f}s "
+                f"(last state: {state})"
+            )
+        time.sleep(delay)
+        waited += delay
+        delay = min(delay * 2, _ATHENA_POLL_MAX_SEC)  # exponential backoff
+
+    return _parse_athena_results(athena_client, query_id)
+
+
+def _parse_athena_results(athena_client, query_id: str) -> list[dict]:
+    """Turn Athena's get_query_results response into a list of row dicts.
+
+    Athena returns results as a ResultSet whose first row is the column
+    headers and remaining rows are data. Each cell is {"VarCharValue": ...}
+    (the key is absent for SQL NULLs). This pages through all results.
+    """
+    rows: list[dict] = []
+    column_names: list[str] = []
+    next_token = None
+
+    while True:
+        kwargs = {"QueryExecutionId": query_id}
+        if next_token:
+            kwargs["NextToken"] = next_token
+        resp = athena_client.get_query_results(**kwargs)
+
+        result_rows = resp["ResultSet"]["Rows"]
+        # On the first page, the first row is the header row.
+        if not column_names:
+            column_names = [
+                cell.get("VarCharValue", "") for cell in result_rows[0]["Data"]
+            ]
+            data_rows = result_rows[1:]
+        else:
+            data_rows = result_rows
+
+        for row in data_rows:
+            # A missing "VarCharValue" key means a SQL NULL -> store None.
+            values = [cell.get("VarCharValue") for cell in row["Data"]]
+            rows.append(dict(zip(column_names, values, strict=False)))
+
+        next_token = resp.get("NextToken")
+        if not next_token:
+            break
+
+    return rows
+
+
+# ─── Check Functions ────────────────────────────────────────────────────────
+
+# list_objects_v2 output dict structure for context
+# response = {
+#     "KeyCount": 2,
+#     "Contents": [
+#         {"Key": "silver/part-0.parquet", "Size": 3000, "LastModified": <dt>, ...},
+#         {"Key": "silver/part-1.parquet", "Size": 4000, "LastModified": <dt>, ...},
+#     ],
+# }
 
 
 def check_s3_object_exists(s3_client, bucket: str, prefix: str) -> CheckResult:
     """Verify that data was actually written to S3."""
     response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
-    exists = response.get("KeyCount", 0) > 0
+    exists = response.get("KeyCount", 0) > 0  # .get() returns zero if Keycount missing
     return CheckResult(
         check_name="s3_object_exists",
         passed=exists,
@@ -80,7 +209,7 @@ def check_s3_file_count(
     s3_client, bucket: str, prefix: str, min_files: int = 1, max_files: int = 1000
 ) -> CheckResult:
     """Verify reasonable number of output files (catches runaway partitioning)."""
-    paginator = s3_client.get_paginator("list_objects_v2")
+    paginator = s3_client.get_paginator("list_objects_v2")  # incase object count > 1000
     count = 0
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         count += page.get("KeyCount", 0)
@@ -122,18 +251,6 @@ def check_s3_freshness(
     )
 
 
-# ─── Composite Check Suites ─────────────────────────────────────────────────
-
-
-def _parse_data_root(data_root: str):
-    """Split an s3://bucket/base/prefix URI into (bucket, base_prefix)."""
-    no_scheme = data_root.replace("s3://", "").rstrip("/")
-    parts = no_scheme.split("/", 1)
-    bucket = parts[0]
-    base_prefix = (parts[1] + "/") if len(parts) > 1 else ""
-    return bucket, base_prefix
-
-
 def check_no_unexpected_partitions(
     s3_client, bucket: str, base_prefix: str, expected_year: int
 ) -> CheckResult:
@@ -161,6 +278,31 @@ def check_no_unexpected_partitions(
             else f"STRAY partitions found: {sorted(stray)} (expected only {expected_year})"
         ),
     )
+
+
+def test_evaluate_results_warn_failure_does_not_block(self):
+    """A failed warn-severity check logs but does not fail the suite."""
+    from quality.data_quality_checks import CheckResult, evaluate_results
+
+    results = [
+        CheckResult("a", True, "ok"),
+        CheckResult("b", False, "soft fail", severity="warn"),
+    ]
+    assert evaluate_results(results) is True
+
+
+def test_evaluate_results_error_failure_blocks(self):
+    """A failed error-severity check fails the suite (default)."""
+    from quality.data_quality_checks import CheckResult, evaluate_results
+
+    results = [
+        CheckResult("a", True, "ok"),
+        CheckResult("b", False, "hard fail"),  # severity defaults to error
+    ]
+    assert evaluate_results(results) is False
+
+
+# ─── Composite Check Suites ─────────────────────────────────────────────────
 
 
 def run_bronze_taxi_checks(
@@ -262,13 +404,21 @@ def run_gold_checks(
 
 
 def evaluate_results(results: list[CheckResult]) -> bool:
-    """Log all results and return True if all passed."""
+    """Log all results and return True if all blocking checks passed.
+    A failed check with severity "warn" is logged as a warning but does
+    not fail the suite. Only failed "error" checks (the default) block.
+    """
     all_passed = True
     for r in results:
         status = "PASS" if r.passed else "FAIL"
         logger.info(f"  [{status}] {r.check_name}: {r.message}")
         if not r.passed:
-            all_passed = False
+            if r.severity == "warn":
+                logger.warning(
+                    f"  [WARN] {r.check_name} failed (non-blocking): {r.message}"
+                )
+            else:
+                all_passed = False
 
     if all_passed:
         logger.info("All data quality checks PASSED")

--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -153,6 +153,288 @@ def _parse_athena_results(athena_client, query_id: str) -> list[dict]:
     return rows
 
 
+# ─── Tier 2: Athena Content Checks ──────────────────────────────────────────
+
+# Row-count floor for silver taxi. NYC yellow does ~3M trips/month; 1M is a
+# conservative floor that still catches a badly truncated load.
+SILVER_TAXI_MIN_ROWS = 1_000_000
+
+# Trend tolerance: a month within +/-50% of the trailing 3-month average is
+# considered normal. Wide because monthly taxi volume genuinely swings with
+# season and events; this only catches gross anomalies (a near-empty or
+# doubled load), not normal variation.
+ROW_COUNT_TREND_TOLERANCE = 0.5
+
+
+def _athena_count(athena_client, config, database: str, sql: str) -> int:
+    """Run a COUNT query and return the integer in its single cell.
+
+    Helper for the count-based checks. Expects sql to select exactly one
+    numeric column in one row (e.g. SELECT COUNT(*) AS n ...).
+    """
+    rows = run_athena_query(
+        athena_client,
+        sql,
+        database=database,
+        workgroup=config.ATHENA_WORKGROUP,
+        output_location=config.ATHENA_OUTPUT_LOCATION,
+    )
+    # rows is [{column_name: "value"}]; take the first (only) value.
+    first_value = next(iter(rows[0].values()))
+    return int(first_value)
+
+
+def check_row_count_floor(
+    athena_client,
+    config,
+    table: str,
+    year: int,
+    month: int,
+    min_rows: int = SILVER_TAXI_MIN_ROWS,
+) -> CheckResult:
+    """Fail if the month's row count is below an absolute floor.
+
+    Catches a load that silently truncated (e.g. a partial file or a
+    transform that dropped most rows). [error]
+    """
+    sql = f"SELECT COUNT(*) AS n FROM {table} WHERE year = {year} AND month = {month}"
+    count = _athena_count(athena_client, config, config.GLUE_DB_SILVER, sql)
+    passed = count >= min_rows
+    return CheckResult(
+        check_name="row_count_floor",
+        passed=passed,
+        message=f"Row count {count:,} (floor: {min_rows:,})",
+        metric_value=count,
+        threshold=min_rows,
+        severity="error",
+    )
+
+
+def check_row_count_trend(
+    athena_client,
+    config,
+    table: str,
+    year: int,
+    month: int,
+    tolerance: float = ROW_COUNT_TREND_TOLERANCE,
+) -> CheckResult:
+    """Warn if the month's row count deviates sharply from recent history.
+
+    Compares this month to the average of the trailing 3 months. If fewer
+    than 3 prior months exist, auto-passes (not enough history to judge).
+    [warn] — seasonal swings are normal, so this informs rather than blocks.
+    """
+    # Pull this month and the 3 prior months, counting rows per month.
+    # We compute the trailing window in SQL by listing the 4 (year, month)
+    # pairs; simpler and cheaper than date math in Athena.
+    months = _trailing_months(year, month, n=4)  # includes current month
+    pairs = ", ".join(f"({y}, {m})" for (y, m) in months)
+    sql = (
+        f"SELECT year, month, COUNT(*) AS n FROM {table} "
+        f"WHERE (year, month) IN ({pairs}) "
+        f"GROUP BY year, month"
+    )
+    rows = run_athena_query(
+        athena_client,
+        sql,
+        database=config.GLUE_DB_SILVER,
+        workgroup=config.ATHENA_WORKGROUP,
+        output_location=config.ATHENA_OUTPUT_LOCATION,
+    )
+    counts = {(int(r["year"]), int(r["month"])): int(r["n"]) for r in rows}
+
+    current = counts.get((year, month), 0)
+    prior = [counts.get((y, m), 0) for (y, m) in months if (y, m) != (year, month)]
+    prior_present = [c for c in prior if c > 0]
+
+    if len(prior_present) < 3:
+        return CheckResult(
+            check_name="row_count_trend",
+            passed=True,
+            message=(
+                f"Only {len(prior_present)} prior month(s) of history; "
+                "skipping trend check"
+            ),
+            severity="warn",
+        )
+
+    avg = sum(prior_present) / len(prior_present)
+    lower = avg * (1 - tolerance)
+    upper = avg * (1 + tolerance)
+    passed = lower <= current <= upper
+    return CheckResult(
+        check_name="row_count_trend",
+        passed=passed,
+        message=(
+            f"Row count {current:,} vs trailing avg {avg:,.0f} "
+            f"(allowed {lower:,.0f}-{upper:,.0f})"
+        ),
+        metric_value=current,
+        threshold=avg,
+        severity="warn",
+    )
+
+
+def _trailing_months(year: int, month: int, n: int) -> list[tuple[int, int]]:
+    """Return the n most recent (year, month) pairs ending at (year, month).
+
+    e.g. _trailing_months(2024, 2, 4) -> [(2023,11),(2023,12),(2024,1),(2024,2)]
+    Handles year rollover.
+    """
+    result = []
+    y, m = year, month
+    for _ in range(n):
+        result.append((y, m))
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+    return sorted(result)
+
+
+# Max acceptable NULL rate per column. 1% allows for rare legitimately-missing
+# values without letting a broken column (mostly null) slip through.
+MAX_NULL_PCT = 0.01
+
+# Max acceptable range-violation rate per rule. 0.5% tolerates a handful of
+# genuine outliers while catching systematic bad data (wrong units, corruption).
+MAX_RANGE_VIOLATION_PCT = 0.005
+
+
+def check_null_rates(
+    athena_client,
+    config,
+    table: str,
+    year: int,
+    month: int,
+    columns: list[str],
+    max_null_pct: float = MAX_NULL_PCT,
+) -> CheckResult:
+    """Fail if any critical column's NULL rate exceeds the threshold.
+
+    Computes NULL percentage per column in a single Athena pass. [error]
+    """
+    # One null-rate expression per column, all in one query.
+    exprs = ", ".join(
+        f'SUM(CASE WHEN {col} IS NULL THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS "{col}"'
+        for col in columns
+    )
+    sql = f"SELECT {exprs} FROM {table} WHERE year = {year} AND month = {month}"
+    rows = run_athena_query(
+        athena_client,
+        sql,
+        database=config.GLUE_DB_SILVER,
+        workgroup=config.ATHENA_WORKGROUP,
+        output_location=config.ATHENA_OUTPUT_LOCATION,
+    )
+    row = rows[0]
+    violations = {
+        col: float(row[col]) for col in columns if float(row[col]) > max_null_pct
+    }
+    passed = len(violations) == 0
+    if passed:
+        message = f"All {len(columns)} columns within {max_null_pct:.1%} null rate"
+    else:
+        detail = ", ".join(f"{c}={p:.2%}" for c, p in violations.items())
+        message = f"NULL rate exceeded ({max_null_pct:.1%}): {detail}"
+    return CheckResult(
+        check_name="null_rates",
+        passed=passed,
+        message=message,
+        severity="error",
+    )
+
+
+def check_value_ranges(
+    athena_client,
+    config,
+    table: str,
+    year: int,
+    month: int,
+    rules: dict,
+    max_violation_pct: float = MAX_RANGE_VIOLATION_PCT,
+) -> CheckResult:
+    """Fail if any column's out-of-range rate exceeds the threshold.
+
+    rules maps column -> (low, high, inclusive_low, inclusive_high). Computes
+    the violation percentage per rule in one Athena pass. [error]
+    """
+    # Build one violation-rate expression per rule.
+    exprs = []
+    for col, (low, high, incl_low, incl_high) in rules.items():
+        lo_op = "<" if incl_low else "<="
+        hi_op = ">" if incl_high else ">="
+        # A row violates if it's below the low bound or above the high bound.
+        exprs.append(
+            f"SUM(CASE WHEN {col} {lo_op} {low} OR {col} {hi_op} {high} "
+            f'THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS "{col}"'
+        )
+    sql = (
+        f"SELECT {', '.join(exprs)} FROM {table} "
+        f"WHERE year = {year} AND month = {month}"
+    )
+    rows = run_athena_query(
+        athena_client,
+        sql,
+        database=config.GLUE_DB_SILVER,
+        workgroup=config.ATHENA_WORKGROUP,
+        output_location=config.ATHENA_OUTPUT_LOCATION,
+    )
+    row = rows[0]
+    violations = {
+        col: float(row[col]) for col in rules if float(row[col]) > max_violation_pct
+    }
+    passed = len(violations) == 0
+    if passed:
+        message = f"All {len(rules)} range rules within {max_violation_pct:.1%}"
+    else:
+        detail = ", ".join(f"{c}={p:.2%}" for c, p in violations.items())
+        message = f"Range violations exceeded ({max_violation_pct:.1%}): {detail}"
+    return CheckResult(
+        check_name="value_ranges",
+        passed=passed,
+        message=message,
+        severity="error",
+    )
+
+
+def check_dates_in_partition(
+    athena_client,
+    config,
+    table: str,
+    year: int,
+    month: int,
+) -> CheckResult:
+    """Fail if any row's pickup_date falls outside the partition's month.
+
+    Catches records whose actual date does not match the year/month
+    partition they were written into (bad source timestamps). [error]
+
+    NOTE: assumes Athena partition metadata is in sync with S3. If
+    partitions were recently added, run MSCK REPAIR TABLE first.
+    """
+    # Count rows where pickup_date is outside [first day, last day] of month.
+    sql = (
+        f"SELECT COUNT(*) AS n FROM {table} "
+        f"WHERE year = {year} AND month = {month} "
+        f"AND (year(pickup_date) <> {year} OR month(pickup_date) <> {month})"
+    )
+    count = _athena_count(athena_client, config, config.GLUE_DB_SILVER, sql)
+    passed = count == 0
+    return CheckResult(
+        check_name="dates_in_partition",
+        passed=passed,
+        message=(
+            "All pickup_date values fall within the partition month"
+            if passed
+            else f"{count:,} rows have pickup_date outside {year}-{month:02d}"
+        ),
+        metric_value=count,
+        threshold=0,
+        severity="error",
+    )
+
+
 # ─── Check Functions ────────────────────────────────────────────────────────
 
 # list_objects_v2 output dict structure for context

--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import argparse
+import calendar
 import logging
 import sys
 import time
@@ -432,6 +433,181 @@ def check_dates_in_partition(
         metric_value=count,
         threshold=0,
         severity="error",
+    )
+
+
+# Minimum fraction of bronze rows that must survive into silver. Below this,
+# the transform is filtering too aggressively (a bug), not just cleaning.
+MIN_SILVER_RETENTION = 0.5
+
+
+def check_calendar_completeness(
+    athena_client,
+    config,
+    database: str,
+    table: str,
+    year: int,
+    month: int,
+    date_column: str,
+) -> CheckResult:
+    """Fail if any calendar day of the month is missing from the table.
+
+    Counts distinct dates present and compares to the number of days in
+    the month. Catches gaps (a missing day of weather or gold). [error]
+    """
+    sql = (
+        f"SELECT COUNT(DISTINCT {date_column}) AS n FROM {table} "
+        f"WHERE year = {year} AND month = {month}"
+    )
+    present = _athena_count(athena_client, config, database, sql)
+    days_in_month = calendar.monthrange(year, month)[1]
+    passed = present == days_in_month
+    return CheckResult(
+        check_name="calendar_completeness",
+        passed=passed,
+        message=(
+            f"All {days_in_month} days present"
+            if passed
+            else f"Only {present}/{days_in_month} days present for {year}-{month:02d}"
+        ),
+        metric_value=present,
+        threshold=days_in_month,
+        severity="error",
+    )
+
+
+def check_cross_layer_counts(
+    athena_client,
+    config,
+    bronze_table: str,
+    silver_table: str,
+    year: int,
+    month: int,
+    min_retention: float = MIN_SILVER_RETENTION,
+) -> CheckResult:
+    """Fail if silver row count is implausible vs bronze.
+
+    Silver must be <= bronze (cleaning only removes rows) AND >= a minimum
+    fraction of bronze (catches over-aggressive filtering). [error]
+
+    NOTE: requires the bronze table to be registered in Glue (issue #50).
+    Until then this check cannot run against real data.
+    """
+    bronze_sql = (
+        f"SELECT COUNT(*) AS n FROM {bronze_table} "
+        f"WHERE year = {year} AND month = {month}"
+    )
+    silver_sql = (
+        f"SELECT COUNT(*) AS n FROM {silver_table} "
+        f"WHERE year = {year} AND month = {month}"
+    )
+    bronze_count = _athena_count(
+        athena_client, config, config.GLUE_DB_BRONZE, bronze_sql
+    )
+    silver_count = _athena_count(
+        athena_client, config, config.GLUE_DB_SILVER, silver_sql
+    )
+
+    if bronze_count == 0:
+        return CheckResult(
+            check_name="cross_layer_counts",
+            passed=False,
+            message="Bronze count is 0; cannot compare layers",
+            severity="error",
+        )
+
+    retention = silver_count / bronze_count
+    passed = silver_count <= bronze_count and retention >= min_retention
+    return CheckResult(
+        check_name="cross_layer_counts",
+        passed=passed,
+        message=(
+            f"Silver {silver_count:,} / Bronze {bronze_count:,} "
+            f"(retention {retention:.1%}, min {min_retention:.0%})"
+        ),
+        metric_value=retention,
+        threshold=min_retention,
+        severity="error",
+    )
+
+
+def check_gold_reconciliation(
+    athena_client,
+    config,
+    year: int,
+    month: int,
+) -> CheckResult:
+    """Fail if gold trip totals don't exactly match silver row count.
+
+    sum(total_trips) in gold trip_weather_daily must equal the silver taxi
+    row count for the month. Proves the gold aggregation neither dropped
+    nor duplicated trips. [error]
+    """
+    gold_sql = (
+        f"SELECT SUM(total_trips) AS n FROM trip_weather_daily "
+        f"WHERE year = {year} AND month = {month}"
+    )
+    silver_sql = (
+        f"SELECT COUNT(*) AS n FROM yellow_taxi_trips "
+        f"WHERE year = {year} AND month = {month}"
+    )
+    gold_total = _athena_count(athena_client, config, config.GLUE_DB_GOLD, gold_sql)
+    silver_total = _athena_count(
+        athena_client, config, config.GLUE_DB_SILVER, silver_sql
+    )
+    passed = gold_total == silver_total
+    return CheckResult(
+        check_name="gold_reconciliation",
+        passed=passed,
+        message=(
+            f"Gold trips {gold_total:,} == silver rows {silver_total:,}"
+            if passed
+            else f"MISMATCH: gold trips {gold_total:,} vs silver rows "
+            f"{silver_total:,} (diff {gold_total - silver_total:+,})"
+        ),
+        metric_value=gold_total,
+        threshold=silver_total,
+        severity="error",
+    )
+
+
+def check_stat_bounds(
+    athena_client,
+    config,
+    database: str,
+    table: str,
+    year: int,
+    month: int,
+    metric_sql: str,
+    lo: float,
+    hi: float,
+    metric_name: str = "metric",
+) -> CheckResult:
+    """Warn if a statistical metric falls outside an expected range.
+
+    metric_sql is an aggregate expression (e.g. "AVG(fare_amount)"). This
+    is a sanity proxy, not ground truth, so it warns rather than blocks.
+    [warn]
+    """
+    sql = (
+        f"SELECT {metric_sql} AS n FROM {table} WHERE year = {year} AND month = {month}"
+    )
+    rows = run_athena_query(
+        athena_client,
+        sql,
+        database=database,
+        workgroup=config.ATHENA_WORKGROUP,
+        output_location=config.ATHENA_OUTPUT_LOCATION,
+    )
+    value = float(next(iter(rows[0].values())))
+    passed = lo <= value <= hi
+    return CheckResult(
+        check_name="stat_bounds",
+        passed=passed,
+        message=f"{metric_name}={value:.2f} (expected {lo}-{hi})",
+        metric_value=value,
+        threshold=hi,
+        severity="warn",
     )
 
 

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -75,6 +75,26 @@ class TestDataQualityChecks:
         ]
         assert evaluate_results(results) is False
 
+    def test_evaluate_results_warn_failure_does_not_block(self):
+        """A failed warn-severity check logs but does not fail the suite."""
+        from quality.data_quality_checks import CheckResult, evaluate_results
+
+        results = [
+            CheckResult("a", True, "ok"),
+            CheckResult("b", False, "soft fail", severity="warn"),
+        ]
+        assert evaluate_results(results) is True
+
+    def test_evaluate_results_error_failure_blocks(self):
+        """A failed error-severity check fails the suite (default)."""
+        from quality.data_quality_checks import CheckResult, evaluate_results
+
+        results = [
+            CheckResult("a", True, "ok"),
+            CheckResult("b", False, "hard fail"),  # severity defaults to error
+        ]
+        assert evaluate_results(results) is False
+
     def test_s3_freshness_recent_passes(self):
         """Recent data (within max_age) should pass the freshness check."""
         from datetime import UTC, datetime, timedelta
@@ -192,3 +212,45 @@ class TestAirflowDag:
             )
         except ImportError:
             pytest.skip("Airflow not installed — skipping DAG validation")
+
+
+class TestAthenaHelper:
+    """Tests for the Athena query helper's parsing and state logic."""
+
+    def test_parse_results_maps_headers_and_nulls(self):
+        """First row is headers; missing VarCharValue becomes None."""
+        from quality.data_quality_checks import _parse_athena_results
+
+        mock_athena = MagicMock()
+        mock_athena.get_query_results.return_value = {
+            "ResultSet": {
+                "Rows": [
+                    {"Data": [{"VarCharValue": "cnt"}, {"VarCharValue": "name"}]},
+                    {"Data": [{"VarCharValue": "5"}, {"VarCharValue": "a"}]},
+                    {"Data": [{"VarCharValue": "0"}, {}]},  # NULL in 2nd col
+                ]
+            }
+            # no NextToken -> single page
+        }
+        rows = _parse_athena_results(mock_athena, "qid")
+        assert rows == [
+            {"cnt": "5", "name": "a"},
+            {"cnt": "0", "name": None},
+        ]
+
+    def test_query_failure_raises(self):
+        """A FAILED query state should raise RuntimeError with the reason."""
+        from quality.data_quality_checks import run_athena_query
+
+        mock_athena = MagicMock()
+        mock_athena.start_query_execution.return_value = {"QueryExecutionId": "qid"}
+        mock_athena.get_query_execution.return_value = {
+            "QueryExecution": {
+                "Status": {
+                    "State": "FAILED",
+                    "StateChangeReason": "SYNTAX_ERROR: bad column",
+                }
+            }
+        }
+        with pytest.raises(RuntimeError, match="FAILED"):
+            run_athena_query(mock_athena, "SELECT 1", "db", "wg", "s3://out/")

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -444,3 +444,154 @@ class TestContentChecks:
             )
         assert result.passed is False
         assert result.metric_value == 42
+
+
+class TestCompletenessAndCrossLayer:
+    """Tests for calendar completeness and cross-layer count checks."""
+
+    def _config(self):
+        from config import Config
+
+        return Config()
+
+    def test_calendar_completeness_all_days_present(self):
+        """All days present (31 for December) passes."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "31"}]):
+            result = dq.check_calendar_completeness(
+                MagicMock(), self._config(), "db", "t", 2024, 12, "date"
+            )
+        assert result.passed is True
+
+    def test_calendar_completeness_missing_day_fails(self):
+        """A missing day (30 of 31) fails."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "30"}]):
+            result = dq.check_calendar_completeness(
+                MagicMock(), self._config(), "db", "t", 2024, 12, "date"
+            )
+        assert result.passed is False
+
+    def test_calendar_completeness_handles_february_leap(self):
+        """February 2024 (leap year) expects 29 days."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "29"}]):
+            result = dq.check_calendar_completeness(
+                MagicMock(), self._config(), "db", "t", 2024, 2, "date"
+            )
+        assert result.passed is True
+
+    def test_cross_layer_counts_pass_normal_retention(self):
+        """Silver below bronze and above min retention passes."""
+        from quality import data_quality_checks as dq
+
+        # bronze 1000, silver 900 -> 90% retention.
+        with patch.object(
+            dq, "run_athena_query", side_effect=[[{"n": "1000"}], [{"n": "900"}]]
+        ):
+            result = dq.check_cross_layer_counts(
+                MagicMock(), self._config(), "b", "s", 2024, 12
+            )
+        assert result.passed is True
+
+    def test_cross_layer_counts_fail_over_filtering(self):
+        """Silver far below bronze (under min retention) fails."""
+        from quality import data_quality_checks as dq
+
+        # bronze 1000, silver 100 -> 10% retention, under 50%.
+        with patch.object(
+            dq, "run_athena_query", side_effect=[[{"n": "1000"}], [{"n": "100"}]]
+        ):
+            result = dq.check_cross_layer_counts(
+                MagicMock(), self._config(), "b", "s", 2024, 12
+            )
+        assert result.passed is False
+
+    def test_cross_layer_counts_fail_silver_exceeds_bronze(self):
+        """Silver larger than bronze (impossible) fails."""
+        from quality import data_quality_checks as dq
+
+        # bronze 1000, silver 1200 -> silver > bronze, invalid.
+        with patch.object(
+            dq, "run_athena_query", side_effect=[[{"n": "1000"}], [{"n": "1200"}]]
+        ):
+            result = dq.check_cross_layer_counts(
+                MagicMock(), self._config(), "b", "s", 2024, 12
+            )
+        assert result.passed is False
+
+
+class TestReconciliationAndStats:
+    """Tests for gold reconciliation and statistical-bounds checks."""
+
+    def _config(self):
+        from config import Config
+
+        return Config()
+
+    def test_gold_reconciliation_exact_match_passes(self):
+        """Gold trip total equal to silver row count passes."""
+        from quality import data_quality_checks as dq
+
+        # gold sum 1000, silver count 1000 -> match.
+        with patch.object(
+            dq, "run_athena_query", side_effect=[[{"n": "1000"}], [{"n": "1000"}]]
+        ):
+            result = dq.check_gold_reconciliation(MagicMock(), self._config(), 2024, 12)
+        assert result.passed is True
+
+    def test_gold_reconciliation_mismatch_fails(self):
+        """Any difference between gold and silver totals fails."""
+        from quality import data_quality_checks as dq
+
+        # gold 990, silver 1000 -> 10 trips lost in aggregation.
+        with patch.object(
+            dq, "run_athena_query", side_effect=[[{"n": "990"}], [{"n": "1000"}]]
+        ):
+            result = dq.check_gold_reconciliation(MagicMock(), self._config(), 2024, 12)
+        assert result.passed is False
+        assert "MISMATCH" in result.message
+
+    def test_stat_bounds_within_range_passes(self):
+        """A metric inside the expected range passes."""
+        from quality import data_quality_checks as dq
+
+        # avg fare 18.50, within [5, 50].
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "18.5"}]):
+            result = dq.check_stat_bounds(
+                MagicMock(),
+                self._config(),
+                "db",
+                "t",
+                2024,
+                12,
+                "AVG(fare_amount)",
+                5,
+                50,
+                metric_name="avg_fare",
+            )
+        assert result.passed is True
+
+    def test_stat_bounds_outside_range_warns(self):
+        """A metric outside the range fails but with warn severity."""
+        from quality import data_quality_checks as dq
+
+        # avg fare 120, above [5, 50].
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "120.0"}]):
+            result = dq.check_stat_bounds(
+                MagicMock(),
+                self._config(),
+                "db",
+                "t",
+                2024,
+                12,
+                "AVG(fare_amount)",
+                5,
+                50,
+                metric_name="avg_fare",
+            )
+        assert result.passed is False
+        assert result.severity == "warn"

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -4,7 +4,7 @@ Tests for data quality checks and Airflow DAG structure.
 
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -254,3 +254,193 @@ class TestAthenaHelper:
         }
         with pytest.raises(RuntimeError, match="FAILED"):
             run_athena_query(mock_athena, "SELECT 1", "db", "wg", "s3://out/")
+
+
+class TestRowCountChecks:
+    """Tests for row-count floor and trend checks (tier 2)."""
+
+    def _config(self):
+        from config import Config
+
+        return Config()
+
+    def test_row_count_floor_passes_above_floor(self):
+        """Count at or above the floor passes."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "1500000"}]):
+            result = dq.check_row_count_floor(
+                MagicMock(), self._config(), "t", 2024, 12, min_rows=1_000_000
+            )
+        assert result.passed is True
+        assert result.metric_value == 1_500_000
+
+    def test_row_count_floor_fails_below_floor(self):
+        """Count below the floor fails with error severity."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "50000"}]):
+            result = dq.check_row_count_floor(
+                MagicMock(), self._config(), "t", 2024, 12, min_rows=1_000_000
+            )
+        assert result.passed is False
+        assert result.severity == "error"
+
+    def test_row_count_floor_builds_filtered_sql(self):
+        """SQL should COUNT(*) with the year/month filter."""
+        from quality import data_quality_checks as dq
+
+        captured = {}
+
+        def fake_query(client, sql, **kwargs):
+            captured["sql"] = sql
+            return [{"n": "1000000"}]
+
+        with patch.object(dq, "run_athena_query", side_effect=fake_query):
+            dq.check_row_count_floor(
+                MagicMock(), self._config(), "silver.taxi", 2024, 12
+            )
+        assert "COUNT(*)" in captured["sql"]
+        assert "year = 2024" in captured["sql"]
+        assert "month = 12" in captured["sql"]
+
+    def test_row_count_trend_auto_passes_without_history(self):
+        """Fewer than 3 prior months -> auto-pass, warn severity."""
+        from quality import data_quality_checks as dq
+
+        # Only the current month present, no prior history.
+        with patch.object(
+            dq,
+            "run_athena_query",
+            return_value=[{"year": "2024", "month": "1", "n": "9"}],
+        ):
+            result = dq.check_row_count_trend(MagicMock(), self._config(), "t", 2024, 1)
+        assert result.passed is True
+        assert result.severity == "warn"
+
+    def test_row_count_trend_fails_outside_tolerance(self):
+        """A count far from the trailing average fails (still warn severity)."""
+        from quality import data_quality_checks as dq
+
+        # 3 prior months ~1000 each; current month 100 -> way below 50% band.
+        rows = [
+            {"year": "2023", "month": "10", "n": "1000"},
+            {"year": "2023", "month": "11", "n": "1000"},
+            {"year": "2023", "month": "12", "n": "1000"},
+            {"year": "2024", "month": "1", "n": "100"},
+        ]
+        with patch.object(dq, "run_athena_query", return_value=rows):
+            result = dq.check_row_count_trend(MagicMock(), self._config(), "t", 2024, 1)
+        assert result.passed is False
+        assert result.severity == "warn"
+
+    def test_trailing_months_handles_year_rollover(self):
+        """Trailing window should cross the year boundary correctly."""
+        from quality.data_quality_checks import _trailing_months
+
+        assert _trailing_months(2024, 2, 4) == [
+            (2023, 11),
+            (2023, 12),
+            (2024, 1),
+            (2024, 2),
+        ]
+
+
+class TestContentChecks:
+    """Tests for null-rate, value-range, and date-partition checks."""
+
+    def _config(self):
+        from config import Config
+
+        return Config()
+
+    def test_null_rates_pass_under_threshold(self):
+        """All columns below the null threshold passes."""
+        from quality import data_quality_checks as dq
+
+        # 0.2% and 0.0% null, both under 1%.
+        result_row = [{"pickup_datetime": "0.002", "fare_amount": "0.0"}]
+        with patch.object(dq, "run_athena_query", return_value=result_row):
+            result = dq.check_null_rates(
+                MagicMock(),
+                self._config(),
+                "t",
+                2024,
+                12,
+                columns=["pickup_datetime", "fare_amount"],
+            )
+        assert result.passed is True
+
+    def test_null_rates_fail_over_threshold(self):
+        """A column above the null threshold fails."""
+        from quality import data_quality_checks as dq
+
+        # fare_amount 5% null, over 1%.
+        result_row = [{"pickup_datetime": "0.0", "fare_amount": "0.05"}]
+        with patch.object(dq, "run_athena_query", return_value=result_row):
+            result = dq.check_null_rates(
+                MagicMock(),
+                self._config(),
+                "t",
+                2024,
+                12,
+                columns=["pickup_datetime", "fare_amount"],
+            )
+        assert result.passed is False
+        assert "fare_amount" in result.message
+
+    def test_value_ranges_respects_inclusive_bounds(self):
+        """Range SQL should use the right operators for inclusive bounds."""
+        from quality import data_quality_checks as dq
+
+        captured = {}
+
+        def fake_query(client, sql, **kwargs):
+            captured["sql"] = sql
+            return [{"passenger_count": "0.0"}]
+
+        rules = {"passenger_count": (1, 8, True, True)}  # [1, 8] inclusive
+        with patch.object(dq, "run_athena_query", side_effect=fake_query):
+            dq.check_value_ranges(MagicMock(), self._config(), "t", 2024, 12, rules)
+        # Inclusive low means violation is "< 1"; inclusive high "> 8".
+        assert "passenger_count < 1" in captured["sql"]
+        assert "passenger_count > 8" in captured["sql"]
+
+    def test_value_ranges_fail_over_threshold(self):
+        """A rule violated above the threshold fails."""
+        from quality import data_quality_checks as dq
+
+        # 2% out of range, over 0.5%.
+        with patch.object(
+            dq, "run_athena_query", return_value=[{"fare_amount": "0.02"}]
+        ):
+            result = dq.check_value_ranges(
+                MagicMock(),
+                self._config(),
+                "t",
+                2024,
+                12,
+                rules={"fare_amount": (0, 1000, False, True)},
+            )
+        assert result.passed is False
+
+    def test_dates_in_partition_pass_when_zero(self):
+        """Zero out-of-month rows passes."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "0"}]):
+            result = dq.check_dates_in_partition(
+                MagicMock(), self._config(), "t", 2024, 12
+            )
+        assert result.passed is True
+
+    def test_dates_in_partition_fail_when_nonzero(self):
+        """Any out-of-month rows fails."""
+        from quality import data_quality_checks as dq
+
+        with patch.object(dq, "run_athena_query", return_value=[{"n": "42"}]):
+            result = dq.check_dates_in_partition(
+                MagicMock(), self._config(), "t", 2024, 12
+            )
+        assert result.passed is False
+        assert result.metric_value == 42


### PR DESCRIPTION
Adds the quality checks (#36): content checks that query the
data with Athena, on top of the existing S3 metadata checks.

This PR is the foundation plus all nine check functions. Wiring them
into the suites, DAG, and CLI comes next, along with the README.

Severity field on CheckResult. "error" blocks the pipeline (the
default, so nothing changes for existing checks), "warn" just logs.
evaluate_results skips warn-failures when deciding pass/fail.

run_athena_query helper. Starts a query, polls until it finishes with
backoff and a timeout, parses the results into dicts. Handles the
header row and nulls. 

The nine checks, each unit-tested with a mocked Athena client:
1. row_count_floor - silver taxi has at least 1M rows
2. row_count_trend - within 50% of the last 3 months (warn)
3. null_rates - null % on key columns stays under 1%
4. value_ranges - out-of-range % per column stays under 0.5%
5. dates_in_partition - no rows dated outside their month
6. calendar_completeness - every day of the month is present
7. cross_layer_counts - silver is <= bronze and keeps at least 50%
8. gold_reconciliation - gold trip totals match the silver row count
9. stat_bounds - avg fare/distance look sane (warn)

Also adds ATHENA_OUTPUT_LOCATION to config.

Tests: 46 passed, 14 skipped locally.