### PR TITLE
feat: checks into silver/gold suites

### DIFF
--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -802,32 +802,91 @@ def run_bronze_weather_checks(
 
 
 def run_silver_taxi_checks(
-    data_root: str, year: int, month: int, s3_client=None
+    data_root: str,
+    year: int,
+    month: int,
+    s3_client=None,
+    athena_client=None,
+    config=None,
 ) -> list[CheckResult]:
-    """Run all quality checks for silver taxi data."""
+    """Run all quality checks for silver taxi data.
+
+    Tier 1 (cheap S3 metadata) runs first. Only if every Tier 1 check
+    passes do we run Tier 2 (Athena content checks), so we never spend
+    on Athena when the data isn't even present.
+    """
+    from config import Config
+
     s3_client = s3_client or boto3.client("s3")
+    config = config or Config()
     bucket, base = _parse_data_root(data_root)
     prefix = f"{base}silver/nyc_tlc/yellow/year={year}/month={month:02d}/"
     table_base = f"{base}silver/nyc_tlc/yellow/"
 
+    # Tier 1: cheap S3 metadata checks.
     results = [
         check_s3_object_exists(s3_client, bucket, prefix),
         check_s3_file_size(s3_client, bucket, prefix, min_bytes=5_000_000),
         check_s3_file_count(s3_client, bucket, prefix, min_files=1, max_files=200),
         check_no_unexpected_partitions(s3_client, bucket, table_base, year),
     ]
+
+    # Gate: skip Athena checks if any Tier 1 (blocking) check failed.
+    if not all(r.passed for r in results if r.severity == "error"):
+        logger.info("Tier 1 checks failed; skipping Tier 2 Athena checks")
+        return results
+
+    athena_client = athena_client or boto3.client("athena")
+    table = "yellow_taxi_trips"
+    results.extend(
+        [
+            check_row_count_floor(athena_client, config, table, year, month),
+            check_row_count_trend(athena_client, config, table, year, month),
+            check_null_rates(
+                athena_client,
+                config,
+                table,
+                year,
+                month,
+                columns=["pickup_datetime", "pickup_location_id", "fare_amount"],
+            ),
+            check_value_ranges(
+                athena_client,
+                config,
+                table,
+                year,
+                month,
+                rules={
+                    # (low, high, inclusive_low, inclusive_high)
+                    "fare_amount": (0, 1000, False, True),
+                    "trip_distance": (0, 200, False, True),
+                    "passenger_count": (1, 8, True, True),
+                    "pickup_location_id": (1, 265, True, True),
+                },
+            ),
+            check_dates_in_partition(athena_client, config, table, year, month),
+        ]
+    )
     return results
 
 
 def run_silver_weather_checks(
-    data_root: str, year: int, month: int, s3_client=None
+    data_root: str,
+    year: int,
+    month: int,
+    s3_client=None,
+    athena_client=None,
+    config=None,
 ) -> list[CheckResult]:
     """Run quality checks for silver weather data.
 
-    month is accepted for signature consistency but unused — the annual
-    NOAA file is processed per-year and partitioned across all 12 months.
+    Tier 1 first, then Tier 2 (calendar completeness) only if Tier 1
+    passed.
     """
+    from config import Config
+
     s3_client = s3_client or boto3.client("s3")
+    config = config or Config()
     bucket, base = _parse_data_root(data_root)
     prefix = f"{base}silver/noaa_weather/nyc_daily/year={year}/"
     table_base = f"{base}silver/noaa_weather/nyc_daily/"
@@ -838,14 +897,43 @@ def run_silver_weather_checks(
         check_s3_file_count(s3_client, bucket, prefix, min_files=1, max_files=50),
         check_no_unexpected_partitions(s3_client, bucket, table_base, year),
     ]
+
+    if not all(r.passed for r in results if r.severity == "error"):
+        logger.info("Tier 1 checks failed; skipping Tier 2 Athena checks")
+        return results
+
+    athena_client = athena_client or boto3.client("athena")
+    results.append(
+        check_calendar_completeness(
+            athena_client,
+            config,
+            config.GLUE_DB_SILVER,
+            "nyc_weather_daily",
+            year,
+            month,
+            date_column="date",
+        )
+    )
     return results
 
 
 def run_gold_checks(
-    data_root: str, year: int, month: int, s3_client=None
+    data_root: str,
+    year: int,
+    month: int,
+    s3_client=None,
+    athena_client=None,
+    config=None,
 ) -> list[CheckResult]:
-    """Run all quality checks for gold feature tables."""
+    """Run all quality checks for gold feature tables.
+
+    Tier 1 S3 checks per table first; then Tier 2 (reconciliation,
+    completeness, stat bounds) only if Tier 1 passed.
+    """
+    from config import Config
+
     s3_client = s3_client or boto3.client("s3")
+    config = config or Config()
     bucket, base = _parse_data_root(data_root)
 
     results = []
@@ -858,6 +946,37 @@ def run_gold_checks(
             ]
         )
 
+    if not all(r.passed for r in results if r.severity == "error"):
+        logger.info("Tier 1 checks failed; skipping Tier 2 Athena checks")
+        return results
+
+    athena_client = athena_client or boto3.client("athena")
+    results.extend(
+        [
+            check_gold_reconciliation(athena_client, config, year, month),
+            check_calendar_completeness(
+                athena_client,
+                config,
+                config.GLUE_DB_GOLD,
+                "trip_weather_daily",
+                year,
+                month,
+                date_column="date",
+            ),
+            check_stat_bounds(
+                athena_client,
+                config,
+                config.GLUE_DB_GOLD,
+                "trip_weather_daily",
+                year,
+                month,
+                "AVG(avg_fare)",
+                5,
+                50,
+                metric_name="avg_fare",
+            ),
+        ]
+    )
     return results
 
 

--- a/tests/test_quality_and_dag.py
+++ b/tests/test_quality_and_dag.py
@@ -595,3 +595,52 @@ class TestReconciliationAndStats:
             )
         assert result.passed is False
         assert result.severity == "warn"
+
+
+class TestSuiteWiring:
+    """Tests for tier-1-first gating in the composite suites."""
+
+    def test_silver_taxi_skips_tier2_when_tier1_fails(self):
+        """If a tier 1 check fails, tier 2 Athena checks are skipped."""
+        from quality import data_quality_checks as dq
+
+        # Make the first tier 1 check fail; Athena client should never be
+        # created/used, so patch run_athena_query to blow up if called.
+        failing = dq.CheckResult("s3_object_exists", False, "missing")
+        with (
+            patch.object(dq, "check_s3_object_exists", return_value=failing),
+            patch.object(dq, "run_athena_query", side_effect=AssertionError("called!")),
+        ):
+            results = dq.run_silver_taxi_checks(
+                "s3://b/data-lake", 2024, 12, s3_client=MagicMock()
+            )
+        # Only tier 1 results present; no tier 2 ran.
+        assert any(not r.passed for r in results)
+        assert all(
+            r.check_name not in ("row_count_floor", "null_rates", "value_ranges")
+            for r in results
+        )
+
+    def test_silver_weather_runs_completeness_when_tier1_passes(self):
+        """When tier 1 passes, the weather suite runs the completeness check."""
+        from quality import data_quality_checks as dq
+
+        passing = dq.CheckResult("t1", True, "ok")
+        completeness = dq.CheckResult("calendar_completeness", True, "ok")
+        with (
+            patch.object(dq, "check_s3_object_exists", return_value=passing),
+            patch.object(dq, "check_s3_file_size", return_value=passing),
+            patch.object(dq, "check_s3_file_count", return_value=passing),
+            patch.object(dq, "check_no_unexpected_partitions", return_value=passing),
+            patch.object(
+                dq, "check_calendar_completeness", return_value=completeness
+            ) as mock_cc,
+        ):
+            dq.run_silver_weather_checks(
+                "s3://b/data-lake",
+                2024,
+                12,
+                s3_client=MagicMock(),
+                athena_client=MagicMock(),
+            )
+        assert mock_cc.called


### PR DESCRIPTION
Hooks the Athena checks into the composite suites so they
actually run in the pipeline. Follow-up to the tier 2 checks PR (#36).

How it works:
- Each suite runs the cheap tier 1 S3 checks first. Only if those pass
  does it run the tier 2 Athena checks, so we never spend on Athena
  when the data isn't even there.
- Suites create their own Athena client and config internally, so the
  DAG callable didn't need to change - it still calls each suite with
  (data_root, year, month).

What's wired:
- silver taxi: row count floor + trend, null rates, value ranges,
  dates in partition
- silver weather: calendar completeness
- gold: reconciliation, completeness, stat bounds

Left out for now:
- Cross-layer count check (#7) - it needs the bronze table in Glue
  (#50), so wiring it in would just block until that lands. Add it
  back with #50.
- CLI flags and README for the new checks - follow-up.

Tests: 48 passed, 14 skipped.

Part of #36.