### PR TITLE
Register bronze tables via Glue crawler

### DIFF
--- a/src/quality/data_quality_checks.py
+++ b/src/quality/data_quality_checks.py
@@ -54,6 +54,157 @@ def _parse_data_root(data_root: str) -> tuple:
     return bucket, base_prefix
 
 
+# ─── Check Functions ────────────────────────────────────────────────────────
+
+"""
+list_objects_v2 output dict structure for context
+response = {
+    "KeyCount": 2,
+    "Contents": [
+        {"Key": "silver/part-0.parquet", "Size": 3000, "LastModified": <dt>, ...},
+        {"Key": "silver/part-1.parquet", "Size": 4000, "LastModified": <dt>, ...},
+    ],
+}
+"""
+
+
+def check_s3_object_exists(s3_client, bucket: str, prefix: str) -> CheckResult:
+    """Verify that data was actually written to S3."""
+    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+    exists = response.get("KeyCount", 0) > 0  # .get() returns zero if Keycount missing
+    return CheckResult(
+        check_name="s3_object_exists",
+        passed=exists,
+        message=(
+            f"Found objects at s3://{bucket}/{prefix}"
+            if exists
+            else f"NO objects found at s3://{bucket}/{prefix}"
+        ),
+    )
+
+
+def check_s3_file_size(
+    s3_client, bucket: str, prefix: str, min_bytes: int = 1000
+) -> CheckResult:
+    """Verify that files are not suspiciously small (empty/corrupt)."""
+    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    if "Contents" not in response:
+        return CheckResult(
+            check_name="s3_file_size",
+            passed=False,
+            message=f"No objects found at {prefix}",
+        )
+
+    total_size = sum(obj["Size"] for obj in response["Contents"])
+    passed = total_size >= min_bytes
+    size_mb = total_size / (1024 * 1024)
+
+    return CheckResult(
+        check_name="s3_file_size",
+        passed=passed,
+        message=f"Total size: {size_mb:.2f} MB (min: {min_bytes / 1024:.1f} KB)",
+        metric_value=total_size,
+        threshold=min_bytes,
+    )
+
+
+def check_s3_file_count(
+    s3_client, bucket: str, prefix: str, min_files: int = 1, max_files: int = 1000
+) -> CheckResult:
+    """Verify reasonable number of output files (catches runaway partitioning)."""
+    paginator = s3_client.get_paginator("list_objects_v2")  # incase object count > 1000
+    count = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        count += page.get("KeyCount", 0)
+
+    passed = min_files <= count <= max_files
+    return CheckResult(
+        check_name="s3_file_count",
+        passed=passed,
+        message=f"File count: {count} (expected {min_files}-{max_files})",
+        metric_value=count,
+    )
+
+
+def check_s3_freshness(
+    s3_client, bucket: str, prefix: str, max_age_hours: int = 48
+) -> CheckResult:
+    """Verify that data was written recently (catches stale pipelines)."""
+    from datetime import datetime
+
+    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    if "Contents" not in response:
+        return CheckResult(
+            check_name="s3_freshness",
+            passed=False,
+            message=f"No objects found at {prefix}",
+        )
+
+    latest = max(obj["LastModified"] for obj in response["Contents"])
+    age = datetime.now(UTC) - latest
+    age_hours = age.total_seconds() / 3600
+    passed = age_hours <= max_age_hours
+
+    return CheckResult(
+        check_name="s3_freshness",
+        passed=passed,
+        message=f"Latest file age: {age_hours:.1f} hours (max: {max_age_hours})",
+        metric_value=age_hours,
+        threshold=max_age_hours,
+    )
+
+
+def check_no_unexpected_partitions(
+    s3_client, bucket: str, base_prefix: str, expected_year: int
+) -> CheckResult:
+    """Flag any year=/ partition under a silver/gold path that is not the
+    expected year. Catches stray-year partitions from bad source timestamps
+    leaking through the transforms (see issue #34)."""
+    # List the immediate year=XXXX/ prefixes under the table path.
+    resp = s3_client.list_objects_v2(Bucket=bucket, Prefix=base_prefix, Delimiter="/")
+    prefixes = [p["Prefix"] for p in resp.get("CommonPrefixes", [])]
+    found_years = []
+    for p in prefixes:
+        # p looks like ".../year=2024/"
+        part = p.rstrip("/").split("/")[-1]
+        if part.startswith("year="):
+            found_years.append(part.split("=", 1)[1])
+
+    stray = [y for y in found_years if y != str(expected_year)]
+    passed = len(stray) == 0
+    return CheckResult(
+        check_name="no_unexpected_partitions",
+        passed=passed,
+        message=(
+            f"Only expected year={expected_year} present"
+            if passed
+            else f"STRAY partitions found: {sorted(stray)} (expected only {expected_year})"
+        ),
+    )
+
+
+def test_evaluate_results_warn_failure_does_not_block(self):
+    """A failed warn-severity check logs but does not fail the suite."""
+    from quality.data_quality_checks import CheckResult, evaluate_results
+
+    results = [
+        CheckResult("a", True, "ok"),
+        CheckResult("b", False, "soft fail", severity="warn"),
+    ]
+    assert evaluate_results(results) is True
+
+
+def test_evaluate_results_error_failure_blocks(self):
+    """A failed error-severity check fails the suite (default)."""
+    from quality.data_quality_checks import CheckResult, evaluate_results
+
+    results = [
+        CheckResult("a", True, "ok"),
+        CheckResult("b", False, "hard fail"),  # severity defaults to error
+    ]
+    assert evaluate_results(results) is False
+
+
 # ─── Athena Helper (Tier 2 content checks) ──────────────────────────────────
 
 # Polling tuning. Athena queries are asynchronous: we start one, then poll
@@ -609,155 +760,6 @@ def check_stat_bounds(
         threshold=hi,
         severity="warn",
     )
-
-
-# ─── Check Functions ────────────────────────────────────────────────────────
-
-# list_objects_v2 output dict structure for context
-# response = {
-#     "KeyCount": 2,
-#     "Contents": [
-#         {"Key": "silver/part-0.parquet", "Size": 3000, "LastModified": <dt>, ...},
-#         {"Key": "silver/part-1.parquet", "Size": 4000, "LastModified": <dt>, ...},
-#     ],
-# }
-
-
-def check_s3_object_exists(s3_client, bucket: str, prefix: str) -> CheckResult:
-    """Verify that data was actually written to S3."""
-    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
-    exists = response.get("KeyCount", 0) > 0  # .get() returns zero if Keycount missing
-    return CheckResult(
-        check_name="s3_object_exists",
-        passed=exists,
-        message=(
-            f"Found objects at s3://{bucket}/{prefix}"
-            if exists
-            else f"NO objects found at s3://{bucket}/{prefix}"
-        ),
-    )
-
-
-def check_s3_file_size(
-    s3_client, bucket: str, prefix: str, min_bytes: int = 1000
-) -> CheckResult:
-    """Verify that files are not suspiciously small (empty/corrupt)."""
-    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
-    if "Contents" not in response:
-        return CheckResult(
-            check_name="s3_file_size",
-            passed=False,
-            message=f"No objects found at {prefix}",
-        )
-
-    total_size = sum(obj["Size"] for obj in response["Contents"])
-    passed = total_size >= min_bytes
-    size_mb = total_size / (1024 * 1024)
-
-    return CheckResult(
-        check_name="s3_file_size",
-        passed=passed,
-        message=f"Total size: {size_mb:.2f} MB (min: {min_bytes / 1024:.1f} KB)",
-        metric_value=total_size,
-        threshold=min_bytes,
-    )
-
-
-def check_s3_file_count(
-    s3_client, bucket: str, prefix: str, min_files: int = 1, max_files: int = 1000
-) -> CheckResult:
-    """Verify reasonable number of output files (catches runaway partitioning)."""
-    paginator = s3_client.get_paginator("list_objects_v2")  # incase object count > 1000
-    count = 0
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-        count += page.get("KeyCount", 0)
-
-    passed = min_files <= count <= max_files
-    return CheckResult(
-        check_name="s3_file_count",
-        passed=passed,
-        message=f"File count: {count} (expected {min_files}-{max_files})",
-        metric_value=count,
-    )
-
-
-def check_s3_freshness(
-    s3_client, bucket: str, prefix: str, max_age_hours: int = 48
-) -> CheckResult:
-    """Verify that data was written recently (catches stale pipelines)."""
-    from datetime import datetime
-
-    response = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
-    if "Contents" not in response:
-        return CheckResult(
-            check_name="s3_freshness",
-            passed=False,
-            message=f"No objects found at {prefix}",
-        )
-
-    latest = max(obj["LastModified"] for obj in response["Contents"])
-    age = datetime.now(UTC) - latest
-    age_hours = age.total_seconds() / 3600
-    passed = age_hours <= max_age_hours
-
-    return CheckResult(
-        check_name="s3_freshness",
-        passed=passed,
-        message=f"Latest file age: {age_hours:.1f} hours (max: {max_age_hours})",
-        metric_value=age_hours,
-        threshold=max_age_hours,
-    )
-
-
-def check_no_unexpected_partitions(
-    s3_client, bucket: str, base_prefix: str, expected_year: int
-) -> CheckResult:
-    """Flag any year=/ partition under a silver/gold path that is not the
-    expected year. Catches stray-year partitions from bad source timestamps
-    leaking through the transforms (see issue #34)."""
-    # List the immediate year=XXXX/ prefixes under the table path.
-    resp = s3_client.list_objects_v2(Bucket=bucket, Prefix=base_prefix, Delimiter="/")
-    prefixes = [p["Prefix"] for p in resp.get("CommonPrefixes", [])]
-    found_years = []
-    for p in prefixes:
-        # p looks like ".../year=2024/"
-        part = p.rstrip("/").split("/")[-1]
-        if part.startswith("year="):
-            found_years.append(part.split("=", 1)[1])
-
-    stray = [y for y in found_years if y != str(expected_year)]
-    passed = len(stray) == 0
-    return CheckResult(
-        check_name="no_unexpected_partitions",
-        passed=passed,
-        message=(
-            f"Only expected year={expected_year} present"
-            if passed
-            else f"STRAY partitions found: {sorted(stray)} (expected only {expected_year})"
-        ),
-    )
-
-
-def test_evaluate_results_warn_failure_does_not_block(self):
-    """A failed warn-severity check logs but does not fail the suite."""
-    from quality.data_quality_checks import CheckResult, evaluate_results
-
-    results = [
-        CheckResult("a", True, "ok"),
-        CheckResult("b", False, "soft fail", severity="warn"),
-    ]
-    assert evaluate_results(results) is True
-
-
-def test_evaluate_results_error_failure_blocks(self):
-    """A failed error-severity check fails the suite (default)."""
-    from quality.data_quality_checks import CheckResult, evaluate_results
-
-    results = [
-        CheckResult("a", True, "ok"),
-        CheckResult("b", False, "hard fail"),  # severity defaults to error
-    ]
-    assert evaluate_results(results) is False
 
 
 # ─── Composite Check Suites ─────────────────────────────────────────────────

--- a/terraform/ephemeral/glue_crawler.tf
+++ b/terraform/ephemeral/glue_crawler.tf
@@ -1,0 +1,93 @@
+###############################################################################
+# Glue Crawler — Bronze table registration
+# Bronze data is written as raw parquet straight to S3 (no Spark table
+# registration), so it isn't queryable in Athena. This crawler scans the
+# bronze prefixes and registers tables in the persistent bronze database.
+# Run on demand: `aws glue start-crawler --name <name>`.
+###############################################################################
+
+# Role the crawler assumes. Needs S3 read on the data lake + Glue write.
+resource "aws_iam_role" "bronze_crawler" {
+  name = "${var.project_name}-bronze-crawler-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "glue.amazonaws.com" }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "Bronze Crawler Role"
+  }
+}
+
+# AWS-managed policy covering the Glue catalog + CloudWatch perms a crawler
+# needs. (S3 read is granted separately below, scoped to our bucket.)
+resource "aws_iam_role_policy_attachment" "bronze_crawler_glue" {
+  role       = aws_iam_role.bronze_crawler.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+# Scoped S3 read on the bronze data only.
+resource "aws_iam_role_policy" "bronze_crawler_s3" {
+  name = "s3-bronze-read"
+  role = aws_iam_role.bronze_crawler.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ListBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket", "s3:GetBucketLocation"]
+        Resource = "arn:aws:s3:::nateeatsrice-master-s3"
+        Condition = {
+          StringLike = { "s3:prefix" = ["data-lake/bronze/*"] }
+        }
+      },
+      {
+        Sid      = "ReadBronze"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::nateeatsrice-master-s3/data-lake/bronze/*"
+      }
+    ]
+  })
+}
+
+# The crawler itself. Two S3 targets -> two tables in the bronze database.
+resource "aws_glue_crawler" "bronze" {
+  name          = "${var.project_name}-bronze-crawler-${var.environment}"
+  role          = aws_iam_role.bronze_crawler.arn
+  database_name = "${replace(var.project_name, "-", "_")}_bronze_${var.environment}"
+
+  s3_target {
+    path = "s3://nateeatsrice-master-s3/data-lake/bronze/nyc_tlc/yellow/"
+  }
+
+  s3_target {
+    path = "s3://nateeatsrice-master-s3/data-lake/bronze/noaa_weather/nyc_daily/"
+  }
+
+  # Keep table definitions stable across reruns; only add new columns.
+  schema_change_policy {
+    update_behavior = "UPDATE_IN_DATABASE"
+    delete_behavior = "LOG"
+  }
+
+  configuration = jsonencode({
+    Version = 1.0
+    CrawlerOutput = {
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+    }
+  })
+
+  tags = {
+    Name = "Bronze Crawler"
+  }
+}


### PR DESCRIPTION
Bronze data is written as raw parquet straight to S3, so it was never
registered in Glue and couldn't be queried in Athena. This adds a Glue
crawler that scans the bronze prefixes and registers tables. Closes #50 

What's added (in ephemeral/glue_crawler.tf):
- A Glue crawler targeting the two bronze prefixes (nyc_tlc/yellow and
  noaa_weather/nyc_daily)
- A dedicated IAM role for the crawler (Glue service role + scoped S3
  read on the bronze prefix only)

Design notes:
- Lives in ephemeral, not persistent. The crawler is a recreatable
  task; the tables it writes land in the persistent bronze database, so
  nothing is lost on teardown.
- Chose a crawler over hand-written Terraform table definitions so it
  adapts if the source schema drifts (UPDATE_IN_DATABASE on schema
  change, LOG on delete so it never drops a table).

Verified:
- Crawler ran, registered two tables: yellow, nyc_daily
- Athena query against bronze yellow returned ~2.96M rows for 2024-01

Known follow-up (noted on #7's issue):
- Crawler types the year/month partition columns as STRINGS, while
  silver/gold use integers. The cross-layer check (#7) will need to
  quote bronze partition values when it's wired back in. Does not affect
  #50.